### PR TITLE
Feature/5/signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // ✅ springdoc 최신 호환 버전으로 교체
+    //springdoc 최신 호환 버전으로 교체
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/kcc/groo/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/kcc/groo/common/GlobalExceptionHandler.java
@@ -1,8 +1,9 @@
 package com.kcc.groo.common;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.kcc.groo.common.dto.CommonResponse;
@@ -13,11 +14,56 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GlobalExceptionHandler {
 	
-	@ResponseStatus(HttpStatus.OK)
-	@ExceptionHandler
-	public CommonResponse<String> exceptionHandler (RuntimeException e) {
-		log.error("[exceptionHandler] ex", e);
-		return new CommonResponse<String>("Exception", e.getMessage());
-	}
+	 /**
+	 * @author kys
+	 * @since 2025-09-23
+     * Validation 실패
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldError().getDefaultMessage();
+        log.error("[ValidationException] {}", errorMessage);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(errorMessage, null));
+    }
 
+    /**
+     * @author kys
+	 * @since 2025-09-23
+     * IllegalArgumentException
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("[IllegalArgumentException] {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(e.getMessage(), null));
+    }
+
+    /**
+     * @author kys
+	 * @since 2025-09-23
+     * 인증/인가 관련 예외
+     */
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<CommonResponse<?>> handleSecurityException(SecurityException e) {
+        log.error("[SecurityException] {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new CommonResponse<>("Unauthorized", null));
+    }
+
+    /**
+     * @author kys
+	 * @since 2025-09-23
+     * 그 외 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<?>> handleGeneralException(Exception e) {
+        log.error("[Exception] {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new CommonResponse<>("Internal server error", null));
+    }
 }

--- a/src/main/java/com/kcc/groo/config/PasswordEncodingConfig.java
+++ b/src/main/java/com/kcc/groo/config/PasswordEncodingConfig.java
@@ -8,9 +8,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 public class PasswordEncodingConfig {
     @Bean 
-    public PasswordEncoder passwordEncoder() { //인터페이스: 다양한 암호화 전략 추상화
-    	//스프링 시큐리티에서 제공하는 암호화 방식 중 하나
-    	//비밀번호를 해싱처리
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/kcc/groo/config/RedisConfig.java
+++ b/src/main/java/com/kcc/groo/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.kcc.groo.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory("localhost", 6379);
+	}
+	
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		
+		return template;
+	}
+}

--- a/src/main/java/com/kcc/groo/config/SpringSecurityConfig.java
+++ b/src/main/java/com/kcc/groo/config/SpringSecurityConfig.java
@@ -33,10 +33,12 @@ public class SpringSecurityConfig {
 	                "/api-docs/swagger-config"
 	            ).permitAll()
 	            
-	            // 로그인/회원가입 허용
+	            // 로그인/회원가입 인증 허용
 	            .requestMatchers(
 	                "/api/v1/auth/login",
-	                "/api/v1/users/signup"
+	                "/api/v1/users/signup",
+	                "/api/v1/email/request",
+	                "/api/v1/email/verify"
 	            ).permitAll()
 	            
 	            // 나머지는 인증 필요

--- a/src/main/java/com/kcc/groo/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/kcc/groo/jwt/JwtAuthFilter.java
@@ -43,9 +43,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 			response.getWriter().write("{\"error\":\"Unauthorized\"}");
 			return;
-		} /*
-			 * finally { SecurityContextHolder.clearContext(); }
-			 */
+		}
 		filterChain.doFilter(request, response);
 	}
 	

--- a/src/main/java/com/kcc/groo/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kcc/groo/jwt/JwtTokenProvider.java
@@ -18,6 +18,11 @@ import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * @author kys
+ * @since 2025-09-15
+ * JWT 토큰의 생성, 파싱, 검증 담당 클래스
+ */
 @Slf4j
 @Component
 public class JwtTokenProvider {
@@ -25,11 +30,19 @@ public class JwtTokenProvider {
 	private static final SecretKey key = Jwts.SIG.HS256.key().build();
 	
 	private static final String AUTH_HEADER = "Authorization";
-	private long tokenValidTime = 30*60*1000L;
+	private long tokenValidTime = 24 * 60 * 60 * 1000L; //하루
+
 	
 	@Autowired
 	UserDetailsService userDetailsService;
 	
+	/**
+	 * @param user
+	 * @author kys
+	 * @since 2025-09-15
+	 * @return jwt token
+	 * 사용자 정보를 기반으로 jwt token 생성
+	 */
 	public String generateToken(Users user) {
 		long now = System.currentTimeMillis();
 		Claims claims = Jwts.claims().subject(user.getUserId()).setIssuer(user.getNickName()).issuedAt(new Date(now))
@@ -38,10 +51,24 @@ public class JwtTokenProvider {
 		return Jwts.builder().claims(claims).signWith(key).compact();
 	}
 	
+	/**
+	 * @param request
+	 * @author kys
+	 * @since 2025-09-15
+	 * @return AUTH_HEADER에 담긴 jwt token
+	 * http 요청 헤더에서 jwt 토큰 추출
+	 */
 	public String resolveToken (HttpServletRequest request) {
 		return request.getHeader(AUTH_HEADER);
 	}
 	
+	/**
+	 * @param token
+	 * @author kys
+	 * @since 2025-09-15
+	 * @return Claims
+	 * JWT 문자열을 Claims 객체로 파싱
+	 */
 	private Claims parseClaims(String token) {
 		log.info(token);
 		
@@ -52,10 +79,25 @@ public class JwtTokenProvider {
 				.getPayload();
 	}
 	
+	/**
+	 * @param token
+	 * @author kys
+	 * @since 2025-09-15
+	 * @return userId
+	 * 토큰에서 사용자 ID(subject)를 추출
+	 */
 	public String getUserId (String token) {
 		return parseClaims(token).getSubject();
 	}
 	
+	/**
+	 * @param token
+	 * @author kys
+	 * @since 2025-09-15
+	 * @return Authentication
+	 * 토큰 기반으로 Authentication 객체를 생성
+	 * Spring Security의 인증 객체로 변환되어 SecurityContext에 저장 가능
+	 */
 	public Authentication getAuthentication(String token) {
 		UserDetails userDetails = userDetailsService.loadUserByUsername(getUserId(token));
 		log.info(userDetails.getUsername());
@@ -63,6 +105,13 @@ public class JwtTokenProvider {
 		return new UsernamePasswordAuthenticationToken(userDetails,"",userDetails.getAuthorities());
 	}
 	
+	/**
+	 * @param token
+	 * @author kys
+	 * @since 2025-09-15
+	 * @return true/false
+	 * JWT 유효성을 검증
+	 */
 	public boolean validateToken(String token) {
 		try {
 			Claims claims = parseClaims(token);

--- a/src/main/java/com/kcc/groo/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kcc/groo/jwt/JwtTokenProvider.java
@@ -32,7 +32,7 @@ public class JwtTokenProvider {
 	
 	public String generateToken(Users user) {
 		long now = System.currentTimeMillis();
-		Claims claims = Jwts.claims().subject(user.getUserId()).setIssuer(user.getNickname()).issuedAt(new Date(now))
+		Claims claims = Jwts.claims().subject(user.getUserId()).setIssuer(user.getNickName()).issuedAt(new Date(now))
 				.expiration(new Date(now + tokenValidTime)).build();
 		
 		return Jwts.builder().claims(claims).signWith(key).compact();

--- a/src/main/java/com/kcc/groo/user/controller/UsersApiController.java
+++ b/src/main/java/com/kcc/groo/user/controller/UsersApiController.java
@@ -1,11 +1,13 @@
 package com.kcc.groo.user.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
-//import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kcc.groo.common.dto.CommonResponse;
@@ -13,6 +15,8 @@ import com.kcc.groo.jwt.JwtTokenProvider;
 import com.kcc.groo.user.data.dto.LoginRequest;
 import com.kcc.groo.user.data.dto.SignupRequest;
 import com.kcc.groo.user.data.model.Users;
+import com.kcc.groo.user.service.EmailVerificationService;
+import com.kcc.groo.user.service.MailService;
 import com.kcc.groo.user.service.UserService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,41 +27,117 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequestMapping("/api/v1")
 public class UsersApiController {
-	
+
 	@Autowired
 	UserService userService;
 	@Autowired
 	JwtTokenProvider jwtTokenProvider;
 	@Autowired
 	PasswordEncoder passwordEncoder;
-	
+	@Autowired
+	EmailVerificationService emailVerificationService;
+	@Autowired
+	MailService mailService;
+
+	/**
+	 * @param loginRequest
+	 * @param request
+	 * @return CommonResponse
+	 * @author kys
+	 * @since 2025-09-15
+	 * 사용자 로그인 요청 처리
+	 */
 	@PostMapping("/auth/login")
-	public CommonResponse<String> login (@Valid @RequestBody LoginRequest loginReq, HttpServletRequest request) {
-		log.info("Login request: {}", loginReq);
-		Users users = userService.loginUser(loginReq.getUserId(), loginReq.getPassword());
+	public ResponseEntity<CommonResponse<?>> login(@Valid @RequestBody LoginRequest loginRequest, HttpServletRequest request) {
+		log.info("Login request: {}", loginRequest);
+		Users users = userService.loginUser(loginRequest.getUserId(), loginRequest.getPassword());
 
 		if (users == null) {
-			throw new IllegalArgumentException("can not found account | user info is null");
+			return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(new CommonResponse<>("Account not found", null));
 		}
-		
-		if (!passwordEncoder.matches(loginReq.getPassword(), users.getPassword())) {
-			throw new IllegalArgumentException("can not found account | unmatch user password");
+
+		if (!passwordEncoder.matches(loginRequest.getPassword(), users.getPassword())) {
+			return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new CommonResponse<>("Invalid credentials", null));
 		}
-		return new CommonResponse<String>("Login Success", jwtTokenProvider.generateToken(users));
+		String token = jwtTokenProvider.generateToken(users);
+        return ResponseEntity
+                .ok(new CommonResponse<>("Login success", token));
 	}
 	
-	@PostMapping("/users/signup")
-	public CommonResponse<Users> signup (@Valid @RequestBody SignupRequest signupReq, HttpServletRequest request) {
-		log.info("signup request: {}", signupReq);
-
-		try {
-			Users newUser = userService.insertUser(signupReq.getUserId(), signupReq.getPassword1(), signupReq.getEmail(), 
-					signupReq.getNickName(), signupReq.getGender(), signupReq.getName(), signupReq.getBirth(), signupReq.isCheckPrivacy(), signupReq.isCheckService(), signupReq.isEmailVerified());
-			
-			return new CommonResponse<Users>("Insert User Success", newUser);
-		} catch (Exception e) {
-			e.printStackTrace();
-			return new CommonResponse<>(e.getMessage(), null);
-		}
+	/**
+	 * @param email
+	 * @return CommonResponse
+	 * @author kys
+	 * @since 2025-09-23
+	 * 회원가입 시 입력된 이메일에 인증 코드를 전송
+	 */
+	@PostMapping("/email/request")
+	public ResponseEntity<CommonResponse<?>> confirmEmail (@RequestParam("email") String email) {
+		String code = emailVerificationService.createVerificationCode(email);
+		mailService.sendVerificationEmail(email, code);
+		
+		return ResponseEntity
+                .ok(new CommonResponse<>("Verification code sent", null));
+		
 	}
+	
+	/**
+	 * @param email
+	 * @param code
+	 * @param request
+	 * @return CommonResponse
+	 * @author kys
+	 * @since 2025-09-23
+	 * 회원가입 시 전송된 인증 코드의 일치 여부를 확인
+	 */
+	@PostMapping("/email/verify")
+	public ResponseEntity<CommonResponse<?>> verifyEmailCode (@RequestParam("email") String email, @RequestParam("code") String code, HttpServletRequest request) {
+		boolean verified = emailVerificationService.verifyCode(email, code);
+		if (verified) {
+			request.getSession().setAttribute("verifiedEmail", email);
+			return ResponseEntity
+                    .ok(new CommonResponse<>("Email verification success", null));
+			} else {
+				return ResponseEntity
+	                    .badRequest()
+	                    .body(new CommonResponse<>("Email verification failed", null));		}
+	}
+	
+	/**
+	 * @param request
+	 * @return CommonResponse
+	 * @author kys
+	 * @since 2025-09-23
+	 * 이메일 인증 및 약관 확인 여부를 체크하고 회원 데이터 저장
+	 */
+	@PostMapping("users/signup")
+	public ResponseEntity<CommonResponse<?>> signup(@Valid @RequestBody SignupRequest request) {
+	    if (!emailVerificationService.isVerified(request.getEmail())) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(new CommonResponse<>("Email verification required", null));
+	    }
+
+	    if (!request.isCheckPrivacy() || !request.isCheckService()) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(new CommonResponse<>("Terms agreement required", null));	    }
+
+	    if (!request.getPassword1().equals(request.getPassword2())) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(new CommonResponse<>("Passwords do not match", null));	    }
+
+	    Users newUser = userService.requestInsertUser(request);
+
+	    emailVerificationService.clearVerified(request.getEmail());
+
+	    return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new CommonResponse<>("Signup success", newUser));	}
+
 }

--- a/src/main/java/com/kcc/groo/user/controller/UsersApiController.java
+++ b/src/main/java/com/kcc/groo/user/controller/UsersApiController.java
@@ -1,9 +1,5 @@
 package com.kcc.groo.user.controller;
 
-
-import java.time.LocalDate;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,13 +50,9 @@ public class UsersApiController {
 	public CommonResponse<Users> signup (@Valid @RequestBody SignupRequest signupReq, HttpServletRequest request) {
 		log.info("signup request: {}", signupReq);
 
-		//비밀번호 확인
-		if (!signupReq.getPassword1().equals(signupReq.getPassword2())) {
-			throw new IllegalArgumentException("The password does not match. Please re-enter it.");
-		}
 		try {
 			Users newUser = userService.insertUser(signupReq.getUserId(), signupReq.getPassword1(), signupReq.getEmail(), 
-					signupReq.getNickname(), signupReq.getGender(), signupReq.getName(), signupReq.getBirth());
+					signupReq.getNickName(), signupReq.getGender(), signupReq.getName(), signupReq.getBirth(), signupReq.isCheckPrivacy(), signupReq.isCheckService(), signupReq.isEmailVerified());
 			
 			return new CommonResponse<Users>("Insert User Success", newUser);
 		} catch (Exception e) {

--- a/src/main/java/com/kcc/groo/user/dao/EmailVerificationRepository.java
+++ b/src/main/java/com/kcc/groo/user/dao/EmailVerificationRepository.java
@@ -1,0 +1,9 @@
+package com.kcc.groo.user.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.kcc.groo.user.data.model.EmailVerification;
+
+public interface EmailVerificationRepository extends CrudRepository<EmailVerification, String>{
+
+}

--- a/src/main/java/com/kcc/groo/user/dao/IUsersRepository.java
+++ b/src/main/java/com/kcc/groo/user/dao/IUsersRepository.java
@@ -3,6 +3,7 @@ package com.kcc.groo.user.dao;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.kcc.groo.user.data.model.Users;
@@ -15,5 +16,5 @@ public interface IUsersRepository {
 	int insertUser (Users user);
 	List<Users> selectAllUserId(); //select all userId
 	int existsByUserId (String userId); //check userId in db
-	int updateEmailVerified(boolean emailVerified);
+	int updateEmailVerified(@Param("email") String email, @Param("emailVerified") boolean emailVerified);
 }

--- a/src/main/java/com/kcc/groo/user/dao/IUsersRepository.java
+++ b/src/main/java/com/kcc/groo/user/dao/IUsersRepository.java
@@ -15,4 +15,5 @@ public interface IUsersRepository {
 	int insertUser (Users user);
 	List<Users> selectAllUserId(); //select all userId
 	int existsByUserId (String userId); //check userId in db
+	int updateEmailVerified(boolean emailVerified);
 }

--- a/src/main/java/com/kcc/groo/user/data/dto/EmailVerificationDTO.java
+++ b/src/main/java/com/kcc/groo/user/data/dto/EmailVerificationDTO.java
@@ -1,0 +1,16 @@
+package com.kcc.groo.user.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerificationDTO {
+	
+	private String userId;
+	private String email;
+	private String token;
+
+}

--- a/src/main/java/com/kcc/groo/user/data/dto/SignupRequest.java
+++ b/src/main/java/com/kcc/groo/user/data/dto/SignupRequest.java
@@ -12,12 +12,15 @@ import lombok.NoArgsConstructor;
 public class SignupRequest {
 	
 	String userId; //db에서 중복체크 해야함 -> service
-	String password1; //일치 여부 확인 -> controller
+	String password1; //일치 여부 확인 -> service
 	String password2;
 	String email;
-	String nickname;
+	String nickName;
 	char gender;
 	String name;
 	LocalDate birth;
+	boolean checkPrivacy;
+	boolean checkService;
+	boolean emailVerified;
 
 }

--- a/src/main/java/com/kcc/groo/user/data/dto/SignupRequest.java
+++ b/src/main/java/com/kcc/groo/user/data/dto/SignupRequest.java
@@ -1,7 +1,13 @@
 package com.kcc.groo.user.data.dto;
 
-import java.time.LocalDate;
+import java.util.Date;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,16 +17,41 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SignupRequest {
 	
-	String userId; //db에서 중복체크 해야함 -> service
-	String password1; //일치 여부 확인 -> service
-	String password2;
-	String email;
-	String nickName;
-	char gender;
-	String name;
-	LocalDate birth;
+	@NotBlank(message = "아이디는 필수 입력값입니다.")
+    @Size(min = 4, max = 20, message = "아이디는 4~20자여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문과 숫자만 사용할 수 있습니다.")
+    private String userId;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_\\-+=]{8,20}$",
+        message = "비밀번호는 대/소문자, 숫자를 포함한 8~20자여야 합니다."
+    )
+    private String password1;
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
+    private String password2;
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    @Size(min = 2, max = 15, message = "닉네임은 2~15자여야 합니다.")
+    private String nickName;
+
+    @NotNull(message = "성별은 필수 선택값입니다.")
+    private Character gender;
+
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    @Size(min = 2, max = 30, message = "이름은 2~30자여야 합니다.")
+    private String name;
+
+    @NotNull(message = "생년월일은 필수 입력값입니다.")
+    @Past(message = "생년월일은 과거 날짜여야 합니다.")
+    private Date birth;
+    
 	boolean checkPrivacy;
 	boolean checkService;
-	boolean emailVerified;
 
 }

--- a/src/main/java/com/kcc/groo/user/data/model/EmailVerification.java
+++ b/src/main/java/com/kcc/groo/user/data/model/EmailVerification.java
@@ -2,17 +2,21 @@ package com.kcc.groo.user.data.model;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@RedisHash(value="email_verification", timeToLive = 300)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class EmailVerification {
 	
-	private int verificationId; //pk
 	private String userId; //fk
+	@Id
 	private String token; //verificatin token
 	private LocalDateTime expires_at; //만료 시간 (5분)
 	private boolean isUsed; //토큰 사용 여부

--- a/src/main/java/com/kcc/groo/user/data/model/EmailVerification.java
+++ b/src/main/java/com/kcc/groo/user/data/model/EmailVerification.java
@@ -15,9 +15,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class EmailVerification {
 	
-	private String userId; //fk
 	@Id
-	private String token; //verificatin token
+	private String email; //pk
+	private String code; //verificatin token
 	private LocalDateTime expires_at; //만료 시간 (5분)
 	private boolean isUsed; //토큰 사용 여부
 	private LocalDateTime createdAt; //토큰 생성일

--- a/src/main/java/com/kcc/groo/user/data/model/Users.java
+++ b/src/main/java/com/kcc/groo/user/data/model/Users.java
@@ -1,7 +1,7 @@
 package com.kcc.groo.user.data.model;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,7 +20,7 @@ public class Users {
 	private String introduction; //자기소개
 	private char gender; //성별
 	private String name; //이름
-	private LocalDate birth; //생년월일
+	private Date birth; //생년월일
 	private LocalDateTime createdAt; //계정 생성일
 	private boolean status; //탈퇴 상태
 	private LocalDateTime withdrawalDate; //탈퇴일

--- a/src/main/java/com/kcc/groo/user/data/model/Users.java
+++ b/src/main/java/com/kcc/groo/user/data/model/Users.java
@@ -15,7 +15,7 @@ public class Users {
 	private String userId; //pk
 	private String password; //비밀번호
 	private String email; //이메일
-	private String nickname; //별명
+	private String nickName; //별명
 	private String profileImage; //프로필 이미지
 	private String introduction; //자기소개
 	private char gender; //성별
@@ -25,6 +25,8 @@ public class Users {
 	private boolean status; //탈퇴 상태
 	private LocalDateTime withdrawalDate; //탈퇴일
 	private LocalDateTime pwdChangedAt; //비밀변호 변경일
-	private boolean emailVerify;
+	private boolean checkPrivacy; //개인정보 이용 동의
+	private boolean checkService; //서비스 이용 동의
+	private boolean emailVerified;
 
 }

--- a/src/main/java/com/kcc/groo/user/service/EmailVerificationService.java
+++ b/src/main/java/com/kcc/groo/user/service/EmailVerificationService.java
@@ -1,0 +1,8 @@
+package com.kcc.groo.user.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailVerificationService {
+
+}

--- a/src/main/java/com/kcc/groo/user/service/EmailVerificationService.java
+++ b/src/main/java/com/kcc/groo/user/service/EmailVerificationService.java
@@ -1,8 +1,48 @@
 package com.kcc.groo.user.service;
 
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-@Service
-public class EmailVerificationService {
+import com.kcc.groo.user.dao.EmailVerificationRepository;
 
+@Service
+public class EmailVerificationService implements IEmailVerificationService {
+
+	@Autowired
+	EmailVerificationRepository emailVerificationRepository;
+	@Autowired
+	RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	public String createVerificationCode(String email) {
+		String code = String.valueOf((int) (Math.random() * 900000) + 100000);
+		redisTemplate.opsForValue().set("verify:" + email, code, 5, TimeUnit.MINUTES);
+
+		return code;
+	}
+
+	@Override
+	public boolean verifyCode(String email, String inputCode) {
+		String savedCode = (String) redisTemplate.opsForValue().get("verify:" + email);
+		if (savedCode == null || !savedCode.equals(inputCode)) {
+			return false;
+		}
+
+		redisTemplate.opsForValue().set("verified:" + email, "true", 10, TimeUnit.MINUTES);
+
+		// 일치하면 즉시 삭제 (재사용 방지)
+		redisTemplate.delete("verify:" + email);
+		return true;
+	}
+
+	public boolean isVerified(String email) {
+		return "true".equals(redisTemplate.opsForValue().get("verified:" + email));
+	}
+
+	public void clearVerified(String email) {
+		redisTemplate.delete("verified:" + email);
+	}
 }

--- a/src/main/java/com/kcc/groo/user/service/IEmailVerificationService.java
+++ b/src/main/java/com/kcc/groo/user/service/IEmailVerificationService.java
@@ -1,0 +1,12 @@
+package com.kcc.groo.user.service;
+
+import org.springframework.data.repository.query.Param;
+
+public interface IEmailVerificationService {
+	
+	String createVerificationCode (@Param("email") String email);
+	boolean verifyCode(@Param("email") String email, @Param("inputCode") String inputCode);
+	boolean isVerified(String email);
+
+
+}

--- a/src/main/java/com/kcc/groo/user/service/IUserService.java
+++ b/src/main/java/com/kcc/groo/user/service/IUserService.java
@@ -1,7 +1,8 @@
 package com.kcc.groo.user.service;
 
-import java.time.LocalDate;
 import java.util.List;
+
+import org.springframework.data.repository.query.Param;
 
 import com.kcc.groo.user.data.dto.SignupRequest;
 import com.kcc.groo.user.data.model.Users;
@@ -11,9 +12,9 @@ public interface IUserService {
 	
 	Users loginUser (String userId, String password);
 	
-	Users insertUser (SignupRequest signupRequest); //2025-09-18 (이메일 인증 미포함 회원 가입) kys
-	
-	String verificationEmail (String email);
+	Users requestInsertUser (SignupRequest signupRequest);
+
+	boolean confirmEmail (@Param("email") String email, @Param("code") String code);
 	
 	List<Users> selectAllUserId();
 }

--- a/src/main/java/com/kcc/groo/user/service/IUserService.java
+++ b/src/main/java/com/kcc/groo/user/service/IUserService.java
@@ -3,6 +3,7 @@ package com.kcc.groo.user.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.kcc.groo.user.data.dto.SignupRequest;
 import com.kcc.groo.user.data.model.Users;
 
 public interface IUserService {
@@ -10,8 +11,9 @@ public interface IUserService {
 	
 	Users loginUser (String userId, String password);
 	
-	Users insertUser (String userId, String rawPassword, String email, String nickName, char gender, String name, 
-			LocalDate birth); //2025-09-18 (이메일 인증 미포함 회원 가입) kys
+	Users insertUser (SignupRequest signupRequest); //2025-09-18 (이메일 인증 미포함 회원 가입) kys
+	
+	String verificationEmail (String email);
 	
 	List<Users> selectAllUserId();
 }

--- a/src/main/java/com/kcc/groo/user/service/MailService.java
+++ b/src/main/java/com/kcc/groo/user/service/MailService.java
@@ -1,0 +1,59 @@
+package com.kcc.groo.user.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+@Service
+public class MailService {
+	
+	@Autowired
+	JavaMailSender javaMailSender;
+	
+	public void sendVerificationEmail (String toEmail, String code) {
+		 String subject = "이메일 인증번호 안내";
+		 String content = """
+			        <div style="max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; color: #333;">
+			            <h2 style="text-align: center; color: #4CAF50;">그루(Groo) 이메일 인증</h2>
+			            <p style="font-size: 16px; text-align: center;">
+			            <br/>
+			                아래 인증번호를 입력하여 이메일 인증을 완료해 주세요.
+			            </p>
+			            <div style="margin: 30px auto; padding: 20px; border-radius: 8px; background: #f4f6f8; text-align: center; width: fit-content;">
+			                <span style="font-size: 28px; font-weight: bold; color: #2c3e50; letter-spacing: 3px;">
+			                    %s
+			                </span>
+			            </div>
+			            <p style="text-align: center; font-size: 14px; color: #777;">
+			                인증번호는 <b style="color:red;">5분간</b> 유효합니다.<br/>
+			            </p>
+			            <hr style="margin: 40px 0;"/>
+			            <p style="text-align: center; font-size: 12px; color: #aaa;">
+			                © 2025 Groo Project. All rights reserved.
+			            </p>
+			        </div>
+			    """.formatted(code);
+;
+		 
+		 sendHtmlMail (toEmail, subject, content);
+	}
+	
+	private void sendHtmlMail (String toEmail, String subject, String content) {
+		try {
+			MimeMessage message = javaMailSender.createMimeMessage();
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+			
+			helper.setTo(toEmail);
+			helper.setSubject(subject);
+			helper.setText(content, true);
+			
+			javaMailSender.send(message);
+		} catch (MessagingException e) {
+			throw new RuntimeException("failed send email ", e);
+		}
+	}
+}

--- a/src/main/java/com/kcc/groo/user/service/UserService.java
+++ b/src/main/java/com/kcc/groo/user/service/UserService.java
@@ -1,23 +1,32 @@
 package com.kcc.groo.user.service;
 
-import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.kcc.groo.user.dao.IUsersRepository;
+import com.kcc.groo.user.data.dto.SignupRequest;
 import com.kcc.groo.user.data.model.Users;
 
 @Service
 public class UserService implements IUserService{
-	
+
 	@Autowired
 	IUsersRepository usersRepository;
 	
 	@Autowired
 	PasswordEncoder passwordEncoder;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+    
+    @Autowired
+    JavaMailSender javaMailSender;
 
 	/**
 	 * @param userId
@@ -32,6 +41,12 @@ public class UserService implements IUserService{
 		if(user == null) {
 			throw new IllegalArgumentException("can not found account");
 		}
+		if (!user.isEmailVerified()) {
+			throw new IllegalStateException("need to verified email");
+		}
+		if(!passwordEncoder.matches(password, user.getPassword())) {
+	        throw new IllegalArgumentException("password does not match");
+	    }
 		
 		return user;
 	}
@@ -47,24 +62,31 @@ public class UserService implements IUserService{
 	 * @return
 	 */
 	@Override
-	public Users insertUser(String userId, String rawPassword, String email, String nickName, char gender, String name,
-			LocalDate birth) {
+	public Users insertUser(SignupRequest signupRequest) {
 		// TODO Auto-generated method stub
 		
-		if(usersRepository.existsByUserId(userId) > 0) {
+		if(usersRepository.existsByUserId(signupRequest.getUserId()) > 0) {
 		throw new IllegalArgumentException("already exist id");	
 		}
 		
-		Users user = new Users();
-		user.setUserId(userId);
-		user.setPassword(passwordEncoder.encode(rawPassword));
-		user.setEmail(email);
-		user.setNickname(nickName);
-		user.setGender(gender);
-		user.setName(name);
-		user.setBirth(birth);
+		int result = 0;
 		
-		int result =  usersRepository.insertUser(user);
+		Users user = new Users();
+		user.setUserId(signupRequest.getUserId());
+		
+		if (signupRequest.getPassword1().equals(signupRequest.getPassword2())) {
+			user.setPassword(passwordEncoder.encode(signupRequest.getPassword1()));
+		}
+		user.setEmail(signupRequest.getEmail());
+		user.setNickName(signupRequest.getNickName());
+		user.setGender(signupRequest.getGender());
+		user.setName(signupRequest.getName());
+		user.setBirth(signupRequest.getBirth());
+		user.setCheckPrivacy(signupRequest.isCheckPrivacy());
+		user.setCheckService(signupRequest.isCheckService());
+		user.setEmailVerified(false);
+		
+		result =  usersRepository.insertUser(user);
 		
 		if (result > 0) {
 			return user;
@@ -74,9 +96,18 @@ public class UserService implements IUserService{
 	}
 
 	@Override
+	public String verificationEmail(String email) {
+		// TODO Auto-generated method stub
+		
+		return null;
+	}
+	
+	@Override
 	public List<Users> selectAllUserId() {
 		// TODO Auto-generated method stub
 		return usersRepository.selectAllUserId();
 	}
+
+
 
 }

--- a/src/main/java/com/kcc/groo/user/service/UserService.java
+++ b/src/main/java/com/kcc/groo/user/service/UserService.java
@@ -1,11 +1,9 @@
 package com.kcc.groo.user.service;
 
+import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -23,10 +21,10 @@ public class UserService implements IUserService{
 	PasswordEncoder passwordEncoder;
 
     @Autowired
-    RedisTemplate<String, String> redisTemplate;
+    EmailVerificationService emailVerificationService;
     
     @Autowired
-    JavaMailSender javaMailSender;
+    MailService mailService;
 
 	/**
 	 * @param userId
@@ -51,57 +49,56 @@ public class UserService implements IUserService{
 		return user;
 	}
 
-	/**
-	 * @param userId
-	 * @param rawPassword
-	 * @param email
-	 * @param nickName
-	 * @param gender
-	 * @param name
-	 * @param birth
-	 * @return
-	 */
+	
 	@Override
-	public Users insertUser(SignupRequest signupRequest) {
+	public Users requestInsertUser(SignupRequest signupRequest) {
 		// TODO Auto-generated method stub
+		
 		
 		if(usersRepository.existsByUserId(signupRequest.getUserId()) > 0) {
 		throw new IllegalArgumentException("already exist id");	
 		}
 		
-		int result = 0;
+		Users newUser = new Users();
+	    newUser.setUserId(signupRequest.getUserId());
+	    newUser.setPassword(passwordEncoder.encode(signupRequest.getPassword1()));
+	    newUser.setEmail(signupRequest.getEmail());
+	    newUser.setNickName(signupRequest.getNickName());
+	    newUser.setGender(signupRequest.getGender());
+	    newUser.setName(signupRequest.getName());
+	    newUser.setBirth(signupRequest.getBirth());
+	    newUser.setCheckPrivacy(signupRequest.isCheckPrivacy());
+	    newUser.setCheckService(signupRequest.isCheckService());
+	    newUser.setEmailVerified(true);
 		
-		Users user = new Users();
-		user.setUserId(signupRequest.getUserId());
-		
-		if (signupRequest.getPassword1().equals(signupRequest.getPassword2())) {
-			user.setPassword(passwordEncoder.encode(signupRequest.getPassword1()));
-		}
-		user.setEmail(signupRequest.getEmail());
-		user.setNickName(signupRequest.getNickName());
-		user.setGender(signupRequest.getGender());
-		user.setName(signupRequest.getName());
-		user.setBirth(signupRequest.getBirth());
-		user.setCheckPrivacy(signupRequest.isCheckPrivacy());
-		user.setCheckService(signupRequest.isCheckService());
-		user.setEmailVerified(false);
-		
-		result =  usersRepository.insertUser(user);
+		int result =  usersRepository.insertUser(newUser);
+		//String email = signupRequest.getEmail();
 		
 		if (result > 0) {
-			return user;
+			/*
+			 * String code = emailVerificationService.createVerificationCode(email);
+			 * mailService.sendVerificationEmail(email, code);
+			 */
+			return newUser;
 		} else {
 			throw new RuntimeException("failed signup");
 		}
 	}
 
-	@Override
-	public String verificationEmail(String email) {
-		// TODO Auto-generated method stub
-		
-		return null;
-	}
 	
+	@Override
+	public boolean confirmEmail(String email, String code) {
+		// TODO Auto-generated method stub
+		boolean verified = emailVerificationService.verifyCode(email, code);
+		if (!verified) {
+			return false;
+		}
+		
+		int updated = usersRepository.updateEmailVerified(email, verified);
+		
+		return updated > 0;
+	}
+
 	@Override
 	public List<Users> selectAllUserId() {
 		// TODO Auto-generated method stub

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,8 +57,18 @@ spring.cache.redis.use-key-prefix=true
 spring.cache.redis.key-prefix=groo:cache:
 
 # 그루 프로젝트 토큰 만료 시간 설정
-groo.token.email-verification-expiration=300000
-groo.token.jwt-access-expiration=900000
-groo.token.jwt-refresh-expiration=604800000
-groo.token.session-timeout=86400000
-groo.token.password-reset-expiration=1800000
+groo.token.email-verification-expiration=300000 
+#비밀번호 재설정 토큰 시간 변경 (2025-09-23 modified by kys)
+groo.token.password-reset-expiration=300000
+#사용 안 하는 토큰 주석처리 (2025-09-23 modified by kys)
+#groo.token.jwt-access-expiration=900000 
+#groo.token.jwt-refresh-expiration=604800000
+#groo.token.session-timeout=86400000
+
+#email sender 설정
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=information.groo@gmail.com
+spring.mail.password=bfna yqxh kkpb uuqg
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/mapper/users/UsersMapper.xml
+++ b/src/main/resources/mapper/users/UsersMapper.xml
@@ -7,7 +7,7 @@
 <id property="userId" column="user_id"/>
 <id property="password" column="password"/>
 <id property="email" column="email"/>
-<id property="nickname" column="nickname"/>
+<id property="nickName" column="nickname"/>
 <id property="profileImage" column="profile_image"/>
 <id property="introduction" column="introduction"/>
 <id property="gender" column="gender"/>
@@ -17,8 +17,9 @@
 <id property="status" column="status"/>
 <id property="withdrawaDate" column="withdrawal_date"/>
 <id property="pwd_changedAt" column="pwd_changed_at"/>
-<id property="emailVerify" column="email_verify"/>
-
+<id property="checkPrivacy" column="check_privacy"/>
+<id property="checkService" column="check_service"/>
+<id property="emailVerified" column="email_Verified"/>
 </resultMap>
 <!-- select -->
 <select id="selectUserByUserId" parameterType="string" resultMap="userMap">
@@ -30,10 +31,16 @@ FROM users WHERE user_id = #{userId}
 
 <insert id="insertUser" parameterType="com.kcc.groo.user.data.model.Users">
 <![CDATA[ 
-INSERT INTO users (user_id, password, email, nickname, gender, name, birth)
-VALUES (#{userId}, #{password}, #{email},#{nickname},#{gender},#{name},#{birth})
+INSERT INTO users (user_id, password, email, nickname, gender, name, birth, check_privacy,check_service )
+VALUES (#{userId}, #{password}, #{email},#{nickName},#{gender},#{name},#{birth}, #{checkPrivacy}, #{checkService})
 ]]>
 </insert>
+
+<update id="updateEmailVerified">
+UPDATE users
+SET email_verified = #{emailVerified}
+WHERE user_id = #{userId}
+</update>
 
 <select id="selectAllUserId" resultMap="userMap">
 <![CDATA[


### PR DESCRIPTION
# Pull Request - Backend

## 🎯 Purpose
<!-- 이 PR의 목적을 명확히 설명해주세요 -->
- [ ] ✨ 새로운 API 추가
- [ ] ♻️ 리팩토링

## 📋 작업 내용
- 회원가입 시 이메일 인증을 통해 가입할 수 있도록 기능 추가
- 회원가입 dto에 validation 추가

```java
@Data
@AllArgsConstructor
@NoArgsConstructor
public class SignupRequest {
	
	@NotBlank(message = "아이디는 필수 입력값입니다.")
    @Size(min = 4, max = 20, message = "아이디는 4~20자여야 합니다.")
    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문과 숫자만 사용할 수 있습니다.")
    private String userId;

    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
    @Pattern(
        regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_\\-+=]{8,20}$",
        message = "비밀번호는 대/소문자, 숫자를 포함한 8~20자여야 합니다."
    )
    private String password1;

    @NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
    private String password2;

    @NotBlank(message = "이메일은 필수 입력값입니다.")
    @Email(message = "올바른 이메일 형식이어야 합니다.")
    private String email;

    @NotBlank(message = "닉네임은 필수 입력값입니다.")
    @Size(min = 2, max = 15, message = "닉네임은 2~15자여야 합니다.")
    private String nickName;

    @NotNull(message = "성별은 필수 선택값입니다.")
    private Character gender;

    @NotBlank(message = "이름은 필수 입력값입니다.")
    @Size(min = 2, max = 30, message = "이름은 2~30자여야 합니다.")
    private String name;

    @NotNull(message = "생년월일은 필수 입력값입니다.")
    @Past(message = "생년월일은 과거 날짜여야 합니다.")
    private Date birth;
    
	boolean checkPrivacy;
	boolean checkService;

}
```

### 주요 변경사항
- 회원가입 시 이메일 인증과 약관 동의가 이루어지지 않았을 경우 데이터를 저장하지 않음
- api 응답 형식 변경

### API 변경사항
<!-- 새로 추가된 엔드포인트나 변경된 API가 있다면 -->
- **POST** `/api/v1/email/request` - 입력된 이메일에 인증코드 전송
<img width="1163" height="192" alt="image" src="https://github.com/user-attachments/assets/7ac8eee5-59fc-4b93-a759-1b006adaace7" />
<img width="2045" height="773" alt="image" src="https://github.com/user-attachments/assets/0096d1c5-ff91-4957-89be-702ce5a0d671" />

- **POST** `/api/v1/email/verify` - 전송된 인증코드 확인 여부
- **수정된 응답 형식** - 설명
<img width="954" height="190" alt="image" src="https://github.com/user-attachments/assets/52ea2e97-9894-4d5c-924c-5e9aa9f0b27c" />

- **POST** `/api/v1/users/signup` - 인증이 확인 된 경우에 가입 완료
<img width="584" height="278" alt="image" src="https://github.com/user-attachments/assets/7856bb3f-78be-46fe-a994-e1086f2a88d3" />

{
  "userId": "testuser123",
  "password1": "Test123456",
  "password2": "Test123456",
  "email": "97yeonsoo@gmail.com",
  "nickName": "test12",
  "gender": "m",
  "name": "test",
  "birth": "1999-08-15",
  "checkPrivacy": true,
  "checkService": true
}
## 🔗 연관된 이슈
> Closes #5 

## 🖥️ 백엔드 체크리스트
- [ ] API 문서 업데이트 (Swagger/Postman)
- [ ] 로그 및 모니터링 설정
- [ ] 에러 핸들링 및 응답 코드 확인

## 🗄️ 데이터베이스 변경사항
- 데이터베이스 테이블 컬럼 일부 수정 (약관 동의 및 이메일 인증 여부 추가)
```sql
-- 유저 테이블
CREATE TABLE users (
    user_id         VARCHAR(50)   NOT NULL COMMENT '사용자 아이디',
    password        VARCHAR(255)  NOT NULL COMMENT '비밀번호',
    email           VARCHAR(100)  NOT NULL COMMENT '이메일',
    nickname        VARCHAR(50)   NOT NULL COMMENT '닉네임',
    profile_image   VARCHAR(255)  NULL COMMENT '프로필 이미지 주소',
    introduction    VARCHAR(255)  NULL COMMENT '자기소개',
    gender          CHAR(1)       NULL COMMENT '성별',
    name            VARCHAR(50)   NULL COMMENT '이름',
    birth           DATE          NULL COMMENT '생년월일',
    created_at      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '계정 생성일',
    status          BOOLEAN       DEFAULT FALSE COMMENT '회원탈퇴 상태 (TRUE=탈퇴, FALSE=활성)',
    withdrawal_date DATETIME      NULL COMMENT '회원탈퇴일',
    pwd_changed_at  DATETIME      NULL COMMENT '비밀번호 수정일',
    check_privacy   BOOLEAN 	  NOT NULL COMMENT '개인정보 이용 동의',
    check_service   BOOLEAN 	  NOT NULL COMMENT '서비스 이용 동의', 
    email_verified BOOLEAN  DEFAULT FALSE COMMENT '회원 인증 상태 (TRUE = 인증, FALSE = 미인증)',
    PRIMARY KEY (user_id),
    UNIQUE KEY uq_email (email),
    CONSTRAINT chk_users_gender CHECK (gender IS NULL OR UPPER(gender) IN ('F', 'M'))
) COMMENT='사용자 테이블';
```

### 특별히 확인해주세요
<!-- /cc @팀원1 @팀원2 -->
@YunSung-Choi97 @umyunho 
