### PR TITLE
fix: 사용자 아이디 찾기 시 이메일 인증 메서드 정리

### DIFF
--- a/src/main/java/com/kcc/groo/config/SpringSecurityConfig.java
+++ b/src/main/java/com/kcc/groo/config/SpringSecurityConfig.java
@@ -38,8 +38,7 @@ public class SpringSecurityConfig {
 	                "/api/v1/auth/login",
 	                "/api/v1/users/signup",
 	                "/api/v1/users/id",
-	                "/api/v1/email/find-id",
-	                "/api/v1/email/request",
+	                "/api/v1/email",
 	                "/api/v1/email/verify"
 	            ).permitAll()
 	            

--- a/src/main/java/com/kcc/groo/user/controller/UsersApiController.java
+++ b/src/main/java/com/kcc/groo/user/controller/UsersApiController.java
@@ -72,32 +72,21 @@ public class UsersApiController {
 	 * @created 2025-09-23
 	 * 회원가입 시 입력된 이메일에 인증 코드를 전송
 	 * 
-	 * @modified 2025-09-24 아이디 찾기 시 이메일 인증과의 분리를 위해 api 추가 아이디 찾기 시 이메일 인증을 위한 메서드명 구분
+	 * @modified 2025-09-25 회원가입 시 인증 / 아이디 찾기 인증 경우에 따라 purpose(String)를 통해 구분 가능하도록 분기
 	 */
-	@PostMapping("/email/signup")
-	public ResponseEntity<CommonResponse<?>> sendSignupCode(@RequestParam("email") String email) {
-		String code = emailVerificationService.createVerificationCode("signup", email);
+	@PostMapping("/email")
+	public ResponseEntity<CommonResponse<?>> sendCode(@RequestParam("email") String email, @RequestParam("purpose") String purpose) {
+		
+		String code = emailVerificationService.createVerificationCode(purpose, email);
 		mailService.sendVerificationEmail(email, code);
 
-		return ResponseEntity.ok(new CommonResponse<>("Signup verification code sent", null));
-
-	}
-
-	/**
-	 * @param email
-	 * @return CommonResponse
-	 * @author kys
-	 * @created 2025-09-24
-	 * 아이디 찾기를 위해 입력된 이메일에 인증 코드를 전송
-	 * 
-	 */
-	@PostMapping("/email/find-id")
-	public ResponseEntity<CommonResponse<?>> sendFindIdCodeAndCheckName(@RequestParam("email") String email) {
-		String code = emailVerificationService.createVerificationCode("findId", email);
-		mailService.sendVerificationEmail(email, code);
-
-		return ResponseEntity.ok(new CommonResponse<>("FindId verification code sent", null));
-
+		if (purpose.equals("signup")) {
+			return ResponseEntity.ok(new CommonResponse<>("Signup verification code sent", code));
+		} else if (purpose.equals("findId")) {
+			return ResponseEntity.ok(new CommonResponse<>("FindId verification code sent", code));
+		} else {
+			return  ResponseEntity.badRequest().body(new CommonResponse<>("Email sending failed", null));
+		}
 	}
 
 	/**


### PR DESCRIPTION
사용자 아이디 찾기 시 컨트롤러에서 중복되는 메서드 코드 정리
관련: #15

# Pull Request - Backend

## 🎯 Purpose
<!-- 이 PR의 목적을 명확히 설명해주세요 -->
- [ ] ♻️ 리팩토링

## 📋 작업 내용
UserApiController 메서드 정리

### 주요 변경사항
- 중복되는 메서드 수정
- purpose 에 따른 분기 처리
```java
	/**
	 * @param email
	 * @return CommonResponse
	 * @author kys
	 * @created 2025-09-23
	 * 회원가입 시 입력된 이메일에 인증 코드를 전송
	 * 
	 * @modified 2025-09-25 회원가입 시 인증 / 아이디 찾기 인증 경우에 따라 purpose(String)를 통해 구분 가능하도록 분기
	 */
	@PostMapping("/email")
	public ResponseEntity<CommonResponse<?>> sendCode(@RequestParam("email") String email, @RequestParam("purpose") String purpose) {
		
		String code = emailVerificationService.createVerificationCode(purpose, email);
		mailService.sendVerificationEmail(email, code);

		if (purpose.equals("signup")) {
			return ResponseEntity.ok(new CommonResponse<>("Signup verification code sent", code));
		} else if (purpose.equals("findId")) {
			return ResponseEntity.ok(new CommonResponse<>("FindId verification code sent", code));
		} else {
			return  ResponseEntity.badRequest().body(new CommonResponse<>("Email sending failed", null));
		}
	}
```

### API 변경사항
<!-- 새로 추가된 엔드포인트나 변경된 API가 있다면 -->
API 명세서와 일치할 수 있도록 수정

## 🔗 연관된 이슈
> Closes #15 


## 🖥️ 백엔드 체크리스트
- [ ] API 문서 업데이트 (Swagger/Postman)
- [ ] 데이터베이스 스키마 변경사항 확인
- [ ] 에러 핸들링 및 응답 코드 확인
- [ ] 보안 검토 (인증/인가, 입력 검증)

## 🗄️ 데이터베이스 변경사항
- [ ] 스키마 변경 없음

### 특별히 확인해주세요
<!-- /cc @팀원1 @팀원2 -->