### PR TITLE
Feat/52/same review search

### DIFF
--- a/database/init_codes.sql
+++ b/database/init_codes.sql
@@ -61,14 +61,14 @@ CREATE TABLE IF NOT EXISTS reviews (
     review_title VARCHAR(200) NOT NULL COMMENT '제목',
     review_content TEXT NOT NULL COMMENT '내용',
     secret BOOLEAN NULL DEFAULT FALSE COMMENT '비밀글',
-    delete_status BOOLEAN NULL DEFAULT TRUE COMMENT '삭제 상태',
+    status BOOLEAN NULL DEFAULT TRUE COMMENT '삭제 상태',
     temporary BOOLEAN NULL DEFAULT FALSE COMMENT '임시 저장 여부',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '작성일',
     updated_at DATETIME NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
     user_id VARCHAR(50) NOT NULL COMMENT '사용자 ID',
     category VARCHAR(50) NOT NULL COMMENT '도서 카테고리',
     PRIMARY KEY (review_id),
-    CONSTRAINT fk_reviews_user FOREIGN KEY (user_id) REFERENCES users(user_id),
+    CONSTRAINT fk_reviews_user FOREIGN KEY (user_id) REFERENCES users(user_id)
 ) COMMENT='독후감';
 
 -- 6. 좋아요 테이블 생성 (users, reviews 참조)
@@ -165,7 +165,7 @@ CREATE TABLE IF NOT EXISTS book (
 ) COMMENT='스크랩 도서';
 
 -- 14. 독서모임 테이블 (users, codes 참조)
-CREATE TABLE IF NOT EXISTS groups (
+CREATE TABLE IF NOT EXISTS `groups` (
     group_id INT NOT NULL AUTO_INCREMENT COMMENT '게시글 ID',
     group_name VARCHAR(100) NULL COMMENT '모임명',
     book_title VARCHAR(200) NULL COMMENT '도서 제목',
@@ -191,7 +191,7 @@ CREATE TABLE IF NOT EXISTS group_scraps (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
     PRIMARY KEY (user_id, group_id),
     CONSTRAINT fk_group_scraps_user FOREIGN KEY (user_id) REFERENCES users(user_id),
-    CONSTRAINT fk_group_scraps_group FOREIGN KEY (group_id) REFERENCES groups(group_id)
+    CONSTRAINT fk_group_scraps_group FOREIGN KEY (group_id) REFERENCES `groups`(group_id)
 ) COMMENT='독서모임 스크랩';
 
 -- 16. 독서모임 댓글 테이블 (groups, users 참조, 자기 참조)
@@ -205,7 +205,7 @@ CREATE TABLE IF NOT EXISTS group_comments (
     user_id VARCHAR(50) NOT NULL COMMENT '사용자 ID',
     parent_id INT NULL COMMENT '부모 댓글',
     PRIMARY KEY (comment_id),
-    CONSTRAINT fk_group_comments_group FOREIGN KEY (group_id) REFERENCES groups(group_id),
+    CONSTRAINT fk_group_comments_group FOREIGN KEY (group_id) REFERENCES `groups`(group_id),
     CONSTRAINT fk_group_comments_user FOREIGN KEY (user_id) REFERENCES users(user_id),
     CONSTRAINT fk_group_comments_parent FOREIGN KEY (parent_id) REFERENCES group_comments(comment_id)
 ) COMMENT='독서모임 댓글';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
           echo 'No migration files found, skipping...';
         fi &&
 
-        echo '✅ All migrations applied.'
+        echo ' All migrations applied.'
       "
     env_file:
       - ./db.env
@@ -104,7 +104,7 @@ services:
     depends_on:
       - db
       - redis
-      - migrator # ✅ 마이그레이션이 끝난 후 실행
+      - migrator #  마이그레이션이 끝난 후 실행
     networks:
       - kcc-network
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,8 +1,18 @@
-# 가상 호스트 서버 블록 정의
+# ------------------------------------------------------------
+# Backend Upstream 정의 (STS + Docker 둘 다 지원)
+# ------------------------------------------------------------
+upstream backend_upstream {
+    # Docker Compose 네트워크에서 groo-backend 컨테이너로 실행
+    server groo-backend:8080 max_fails=3 fail_timeout=5s backup;
+
+    # STS (로컬 IDE) 실행 → 호스트의 8080 포트로 접근
+    server host.docker.internal:8080 max_fails=3 fail_timeout=5s ;
+}
+
 server {
     listen 80;
     server_name localhost;
-    
+
     # Docker DNS resolver
     resolver 127.0.0.11 valid=10s ipv6=off;
 
@@ -10,8 +20,7 @@ server {
     # ALB 헬스체크 전용 경로
     # =================================================================
     location /health {
-        set $backend_host host.docker.internal:8080;
-        proxy_pass http://$backend_host/actuator/health;
+        proxy_pass http://backend_upstream/actuator/health;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -22,8 +31,7 @@ server {
     # Swagger UI 프록시 (CORS 허용)
     # =================================================================
     location /swagger-ui/ {
-        set $backend_host host.docker.internal:8080;
-        proxy_pass http://$backend_host/swagger-ui/;
+        proxy_pass http://backend_upstream/swagger-ui/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -42,8 +50,7 @@ server {
     # OpenAPI Docs 프록시 (CORS 허용)
     # =================================================================
     location /v3/api-docs {
-        set $backend_host host.docker.internal:8080;
-        proxy_pass http://$backend_host/v3/api-docs;
+        proxy_pass http://backend_upstream/v3/api-docs;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -108,26 +115,22 @@ server {
     # 백엔드 Spring Boot API 프록시
     # =================================================================
     location /api/ {
-        set $backend_host host.docker.internal:8080;
-        proxy_pass http://$backend_host;
-        
+        proxy_pass http://backend_upstream;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
-        # 타임아웃 설정
+
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
 
-        # CORS - 모든 응답에 항상 추가
         add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
         add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Cookie' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
 
-        # Preflight
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;

--- a/src/main/java/com/kcc/groo/review/controller/ReviewApiController.java
+++ b/src/main/java/com/kcc/groo/review/controller/ReviewApiController.java
@@ -246,4 +246,44 @@ public class ReviewApiController {
         String userId = principal != null ? principal.getName() : null;
         return ResponseEntity.ok(reviewService.getAllReviewsOrderByLikes(userId));
     }
+    
+    /**
+     * @param isbn 조회할 도서의 ISBN
+     * @param principal 인증된 사용자 정보
+     * @return ResponseEntity<List<ReviewResponse>>
+     * @author uyh
+     * @created 2025-10-04
+     * 특정 ISBN의 모든 공개 독후감을 조회 (같은 책을 읽은 다른 유저들의 독후감)
+     */
+    @Operation(summary = "ISBN으로 독후감 조회", description = "특정 도서의 모든 공개 독후감을 최신순으로 조회합니다.")
+    @GetMapping("/isbn/{isbn}")
+    public ResponseEntity<List<ReviewResponse>> getReviewsByIsbn(
+            @PathVariable("isbn") String isbn,
+            Principal principal) {
+        String userId = principal != null ? principal.getName() : null;
+        return ResponseEntity.ok(reviewService.getReviewsByIsbn(isbn, userId));
+    }
+    
+
+    /**
+     * TODO
+     * 
+     * @param category
+     * @param limit
+     * @param principal
+     * @param
+     * @return ResponseEntity<List<ReviewResponse>>
+     * @author uyh
+     * @created 2025. 10. 4. TODO
+     */
+    @Operation(summary = "카테고리로 독후감 조회", description = "특정 카테고리의 모든 공개 독후감을 최신순으로 조회합니다.")
+    @GetMapping("/category")
+    public ResponseEntity<List<ReviewResponse>> getReviewsByCategory(
+            @RequestParam("name") String category,
+            @RequestParam(name = "limit", defaultValue = "20") int limit,
+            Principal principal) {
+        String userId = principal != null ? principal.getName() : null;
+        return ResponseEntity.ok(reviewService.getReviewsByCategory(category, userId, limit));
+    }
+    
 }

--- a/src/main/java/com/kcc/groo/review/dao/IReviewRepository.java
+++ b/src/main/java/com/kcc/groo/review/dao/IReviewRepository.java
@@ -191,4 +191,28 @@ public interface IReviewRepository {
      */
     List<ReviewResponse> selectAllReviewsOrderByLikes(@Param("userId") String userId);
     
+    /**
+     * @param isbn 조회할 ISBN
+     * @param userId 조회하는 사용자 ID
+     * @return List<ReviewResponse>
+     * @author uyh
+     * @created 2025-10-04
+     * 특정 ISBN의 모든 공개 독후감을 조회 (비밀글 제외, 임시저장 제외)
+     */
+    List<ReviewResponse> selectReviewsByIsbn(@Param("isbn") String isbn, 
+                                             @Param("userId") String userId);
+    
+    /**
+     * @param category 조회할 카테고리
+     * @param userId 조회하는 사용자 ID
+     * @param limit 조회할 최대 개수
+     * @return List<ReviewResponse>
+     * @author uyh
+     * @created 2025-10-04
+     * 특정 카테고리의 모든 공개 독후감을 조회 (비밀글 제외, 임시저장 제외)
+     */
+    List<ReviewResponse> selectReviewsByCategory(@Param("category") String category,
+                                                 @Param("userId") String userId,
+                                                 @Param("limit") int limit);
+    
 }

--- a/src/main/java/com/kcc/groo/review/data/dto/ReviewResponse.java
+++ b/src/main/java/com/kcc/groo/review/data/dto/ReviewResponse.java
@@ -21,6 +21,7 @@ public class ReviewResponse {
     private String category;      
     private Integer likeCount;    // 좋아요 개수
     private Boolean liked;        // 현재 로그인 유저가 좋아요 눌렀는지 여부
+    private Boolean isOwner;      // 추가: 현재 로그인 유저가 작성자인지 여부
     private List<CommentResponse> comments;  //  댓글 포함
     private Boolean status;
     private Integer commentCount; // 댓글 개수

--- a/src/main/java/com/kcc/groo/review/service/IReviewService.java
+++ b/src/main/java/com/kcc/groo/review/service/IReviewService.java
@@ -148,5 +148,26 @@ public interface IReviewService {
      * 전체 유저의 독후감을 1주일간 좋아요 많은 순으로 조회
      */
     List<ReviewResponse> getAllReviewsOrderByLikes(String userId);
+
+    /**
+     * @param isbn 조회할 ISBN
+     * @param userId 조회하는 사용자 ID
+     * @return List<ReviewResponse>
+     * @author uyh
+     * @created 2025-10-04
+     * 특정 ISBN의 모든 공개 독후감을 조회
+     */
+    List<ReviewResponse> getReviewsByIsbn(String isbn, String userId);
+    
+    /**
+     * @param category 조회할 카테고리
+     * @param userId 조회하는 사용자 ID
+     * @param limit 조회할 최대 개수
+     * @return List<ReviewResponse>
+     * @author uyh
+     * @created 2025-10-04
+     * 특정 카테고리의 모든 공개 독후감을 조회
+     */
+    List<ReviewResponse> getReviewsByCategory(String category, String userId, int limit);
     
 }

--- a/src/main/java/com/kcc/groo/review/service/ReviewService.java
+++ b/src/main/java/com/kcc/groo/review/service/ReviewService.java
@@ -144,6 +144,10 @@ public class ReviewService implements IReviewService {
             }
         }
         
+        // ========== 추가 ==========
+        // 작성자 여부 설정
+        review.setIsOwner(userId != null && userId.equals(review.getUserId()));
+        
         // 댓글 조회
         if (review != null) {
             review.setComments(reviewRepository.selectCommentsByReview(reviewId));
@@ -323,6 +327,36 @@ public class ReviewService implements IReviewService {
         return reviewRepository.selectAllReviewsOrderByLikes(userId);
     }
     
+    @Override
+    public List<ReviewResponse> getReviewsByIsbn(String isbn, String userId) {
+        if (isbn == null || isbn.trim().isEmpty()) {
+            throw new ReviewException(ReviewErrorCode.INVALID_ISBN);
+        }
+        
+        // ISBN 형식 검증 (10자리 또는 13자리)
+        String cleanIsbn = isbn.replaceAll("-", "");
+        if (!cleanIsbn.matches("^\\d{10}(\\d{3})?$")) {
+            throw new ReviewException(ReviewErrorCode.INVALID_ISBN, "ISBN must be 10 or 13 digits");
+        }
+        
+        log.info("[getReviewsByIsbn] isbn: {}, userId: {}", isbn, userId);
+        return reviewRepository.selectReviewsByIsbn(isbn, userId);
+    }
+    
+    @Override
+    public List<ReviewResponse> getReviewsByCategory(String category, String userId, int limit) {
+        if (category == null || category.trim().isEmpty()) {
+            throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_REQUEST, "Category is required");
+        }
+        
+        if (limit <= 0 || limit > 100) {
+            limit = 20; // 기본값
+        }
+        
+        log.info("[getReviewsByCategory] category: {}, userId: {}, limit: {}", category, userId, limit);
+        return reviewRepository.selectReviewsByCategory(category, userId, limit);
+    }
+    
     // ============ Private Validation Methods ============
     
     /**
@@ -377,4 +411,7 @@ public class ReviewService implements IReviewService {
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }
     }
+    
+    
+    
 }

--- a/src/main/resources/mapper/reviews/CommentMapper.xml
+++ b/src/main/resources/mapper/reviews/CommentMapper.xml
@@ -24,18 +24,19 @@
 	</insert>
 
 	<!-- 부모 댓글 단건 조회 -->
-	<select id="selectCommentById"
-		resultType="com.kcc.groo.review.data.dto.CommentResponse">
-		SELECT
-		c.comment_id AS commentId,
-		c.content AS content,
-		c.user_id AS userId,
-		c.created_at AS createdAt,
-		c.updated_at AS updatedAt,
-		c.parent_id AS parentId
-		FROM review_comments c
-		WHERE c.comment_id = #{commentId}
-	</select>
+<!-- 댓글 단건 조회 -->
+<select id="selectCommentById" resultType="com.kcc.groo.review.data.dto.CommentResponse">
+    SELECT
+        comment_id AS commentId,
+        content AS content,
+        user_id AS userId,
+        created_at AS createdAt,
+        updated_at AS updatedAt,
+        parent_id AS parentId,
+        review_id AS reviewId
+    FROM review_comments
+    WHERE comment_id = #{commentId}
+</select>
 
 	<!-- 댓글 수정 -->
 	<update id="updateComment">

--- a/src/main/resources/mapper/reviews/ReviewMapper.xml
+++ b/src/main/resources/mapper/reviews/ReviewMapper.xml
@@ -10,7 +10,8 @@
 	<!-- 독후감 작성 -->
 	<insert id="insertReview">
 		INSERT INTO reviews (
-		ISBN, review_title, review_content,
+		ISBN, review_title,
+		review_content,
 		secret, status, temporary, created_at,
 		user_id, category
 		) VALUES (
@@ -372,6 +373,71 @@
              r.created_at, r.updated_at, r.user_id, r.category
     ORDER BY likeCount DESC, r.created_at DESC
     ]]>
+	</select>
+
+	<!-- ISBN으로 독후감 조회 (공개글만, 최신순) -->
+	<select id="selectReviewsByIsbn"
+		resultType="com.kcc.groo.review.data.dto.ReviewResponse">
+	<![CDATA[
+	SELECT
+	    r.review_id AS reviewId,
+	    r.ISBN AS isbn,
+	    r.review_title AS reviewTitle,
+	    r.review_content AS reviewContent,
+	    r.secret AS secret,
+	    r.status AS status,
+	    r.temporary AS temporary,
+	    r.created_at AS createdAt,
+	    r.updated_at AS updatedAt,
+	    r.user_id AS userId,
+	    r.category AS category,
+	    (SELECT COUNT(*) FROM likes l WHERE l.review_id = r.review_id) AS likeCount,
+	    (SELECT COUNT(*) FROM review_comments c WHERE c.review_id = r.review_id) AS commentCount,
+	    CASE WHEN #{userId} IS NOT NULL AND EXISTS (
+	        SELECT 1 FROM likes l2 
+	        WHERE l2.review_id = r.review_id 
+	        AND l2.user_id = #{userId}
+	    ) THEN true ELSE false END AS liked
+	FROM reviews r
+	WHERE r.ISBN = #{isbn}
+	    AND r.status = TRUE
+	    AND r.temporary = FALSE
+	    AND r.secret = FALSE
+	ORDER BY r.created_at DESC
+	]]>
+	</select>
+
+	<!-- 카테고리로 독후감 조회 (공개글만, 최신순) -->
+	<select id="selectReviewsByCategory"
+		resultType="com.kcc.groo.review.data.dto.ReviewResponse">
+	<![CDATA[
+	SELECT
+	    r.review_id AS reviewId,
+	    r.ISBN AS isbn,
+	    r.review_title AS reviewTitle,
+	    r.review_content AS reviewContent,
+	    r.secret AS secret,
+	    r.status AS status,
+	    r.temporary AS temporary,
+	    r.created_at AS createdAt,
+	    r.updated_at AS updatedAt,
+	    r.user_id AS userId,
+	    r.category AS category,
+	    (SELECT COUNT(*) FROM likes l WHERE l.review_id = r.review_id) AS likeCount,
+	    (SELECT COUNT(*) FROM review_comments c WHERE c.review_id = r.review_id) AS commentCount,
+	    CASE WHEN #{userId} IS NOT NULL AND EXISTS (
+	        SELECT 1 FROM likes l2 
+	        WHERE l2.review_id = r.review_id 
+	        AND l2.user_id = #{userId}
+	    ) THEN true ELSE false END AS liked
+	FROM reviews r
+	WHERE r.category = #{category}
+	    AND r.status = TRUE
+	    AND r.temporary = FALSE
+	    AND r.secret = FALSE
+	ORDER BY r.created_at DESC
+	LIMIT #{limit}
+	]]>
 	</select>
 
 </mapper>


### PR DESCRIPTION
# Pull Request - Backend

## 🎯 Purpose
<!-- 이 PR의 목적을 명확히 설명해주세요 -->
- [x] ✨ 새로운 API 추가
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] ♻️ 리팩토링
- [ ] 🔧 인프라/환경 설정
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 강화

## 📋 작업 내용
<!-- 구체적으로 무엇을 변경했는지 설명해주세요 -->
독후감 상세 페이지에서 관련 독후감 조회를 위한 API 확장 및 작성자 권한 정보 제공 기능을 추가했습니다.
### 주요 변경사항
ISBN 기반 독후감 조회 API 추가 (같은 도서를 읽은 다른 사용자의 독후감)

카테고리 기반 독후감 조회 API 추가 (같은 장르의 다른 독후감)

독후감 상세 조회 시 작성자 권한 정보(isOwner) 응답에 포함

카테고리명 특수문자(/) 처리를 위해 PathVariable에서 RequestParam으로 변경

리뷰 서비스 및 레포지토리에 새로운 조회 메서드 구현

### API 변경사항
<!-- 새로 추가된 엔드포인트나 변경된 API가 있다면 -->
GET /api/v1/reviews/isbn/{isbn} - 특정 도서의 모든 공개 독후감 조회

GET /api/v1/reviews/category?name={category}&limit={limit} - 특정 카테고리의 독후감 조회 (페이징 지원)

수정된 응답 형식 - ReviewResponse에 isOwner 필드 추가로 작성자 권한 정보 제공

## 🔗 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: #123 -->
> close #52 

## 🖥️ 백엔드 체크리스트
- [x] API 문서 업데이트 (Swagger/Postman)
- [x] 데이터베이스 스키마 변경사항 확인
- [ ] 환경 변수 변경사항 문서화
- [ ] 로그 및 모니터링 설정
- [x] 에러 핸들링 및 응답 코드 확인
- [ ] 보안 검토 (인증/인가, 입력 검증)
- [ ] 성능 테스트 (필요시)

