### PR TITLE
토큰 필터 화이트리스트 및 검증 로직 수정

### DIFF
--- a/src/main/java/com/kcc/groo/config/SpringSecurityConfig.java
+++ b/src/main/java/com/kcc/groo/config/SpringSecurityConfig.java
@@ -27,7 +27,7 @@ public class SpringSecurityConfig {
 	
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-	    
+
 	    http.csrf((csrf)->csrf.disable());
 	    
 	    http.authorizeHttpRequests((authHttpReq) -> authHttpReq
@@ -40,23 +40,27 @@ public class SpringSecurityConfig {
 	                "/api-docs/swagger-config",
 	                "/api/test/ping"
 	            ).permitAll()
-	            
-	            // 로그인/회원가입 / 아이디 / 비밀번호 찾기 인증 허용
+
+                // 로그인, 로그아웃, 토큰재발행 통과
 	            .requestMatchers(
 	                "/api/v1/auth/login",
 	                "/api/v1/auth/logout",
-	                "/api/v1/users/signup",
-	                "/api/v1/users/id/**",
-	                "/api/v1/users/password",
-	                "/api/v1/email",
-	                "/api/v1/email/verify"
+                    "/api/v1/token-refresh"
 	            ).permitAll()
+
+                // 회원가입, ID/PW 찾기, 이메일 인증 통과
+                .requestMatchers(
+                        "/api/v1/users/signup",
+                        "/api/v1/users/id/**",
+                        "/api/v1/users/password",
+                        "/api/v1/email",
+                        "/api/v1/email/verify"
+                ).permitAll()
 	            
 	            // 나머지는 인증 필요
 	            .anyRequest().authenticated()
 	    );
 
-	    
 	    http.sessionManagement((session)-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 	    http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 	    

--- a/src/main/java/com/kcc/groo/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/kcc/groo/jwt/JwtAuthFilter.java
@@ -14,38 +14,98 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * @author cys
+ * @modified 2025-10-11
+ * JWT 인증 필터 (화이트리스트 방식 적용)
+ * - SecurityFilterChain보다 먼저 실행되어, 요청 헤더의 JWT 토큰을 검사
+ * - 화이트리스트에 등록된 경로는 토큰 검사 없이 통과
+ * - 그 외의 모든 경로는 토큰이 유효해야만 통과
+ */
 @Slf4j
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
-	
-	@Autowired
-	private JwtTokenProvider jwtTokenProvider;
-	
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-			throws ServletException, IOException {
-		
-		//로그인 경로 예외
-	    String path = request.getServletPath();
-	    if (path.startsWith("/api/v1/auth") || path.startsWith("/api/v1/users/signup")) {
-	        filterChain.doFilter(request, response);
-	        return;
-	    }
-		
-		try {
-			String token = jwtTokenProvider.resolveAccessToken(request);
-			if (token != null && jwtTokenProvider.validateToken(token)) {
-				Authentication authentication = jwtTokenProvider.getAuthentication(token);
-				SecurityContextHolder.getContext().setAuthentication(authentication);
-		}
-		} catch (Exception e) {
-			response.setContentType("application/json");
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.getWriter().write("{\"error\":\"Unauthorized\"}");
-			return;
-		}
-		filterChain.doFilter(request, response);
-	}
-	
-	
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * JWT 검증을 건너뛸 화이트리스트 경로
+     */
+    private static final String[] PERMIT_URL_ARRAY = {
+            /* 정적 리소스 및 테스트 */
+            "/api/test/ping",
+            "/actuator",
+
+            /* Swagger UI */
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/api-docs",
+
+            /* 로그인, 회원가입, 토큰 재발급 */
+            "/api/v1/auth/login",
+            "/api/v1/users/signup",
+            "/api/v1/token-refresh",
+
+            /* ID/PW 찾기, 이메일 인증 */
+            "/api/v1/users/id",
+            "/api/v1/users/password",
+            "/api/v1/email"
+    };
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String path = request.getServletPath();
+
+        // 화이트리스트 경로 확인
+        for (String permitUrl : PERMIT_URL_ARRAY) {
+            if (path.startsWith(permitUrl)) {
+                filterChain.doFilter(request, response);
+                return; // 화이트리스트 경로인 경우 필터의 나머지 로직을 실행하지 않고 통과
+            }
+        }
+
+        // 화이트리스트가 아닌 경로에 대하여 토큰 검증 수행
+        try {
+            String token = jwtTokenProvider.resolveAccessToken(request);
+
+            // 토큰이 없는 경우 401 반환
+            if (token == null) {
+                log.warn("Access token not found in request");
+                sendUnauthorizedResponse(response, "엑세스 토큰이 필요합니다");
+                return;
+            }
+
+            // 토큰이 유효하지 않은 경우 401 반환 (만료, 위조 등)
+            if (!jwtTokenProvider.validateToken(token)) {
+                log.warn("Invalid or expired access token");
+                sendUnauthorizedResponse(response, "엑세스 토큰이 유효하지 않습니다");
+                return;
+            }
+
+            // 엑세스 토큰이 유효한 경우 인증 정보 설정
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (Exception e) {
+            log.error("JWT authentication failed: {}", e.getMessage());
+            sendUnauthorizedResponse(response, "잘못된 엑세스 토큰입니다.");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * @author uyh
+     * @created 2025-10-11
+     * 401 Unauthorized 응답 전송
+     */
+    private void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(String.format("{\"error\":\"Unauthorized\",\"message\":\"%s\"}", message));
+    }
 }


### PR DESCRIPTION
# Pull Request - Backend

## 🎯 Purpose
<!-- 이 PR의 목적을 명확히 설명해주세요 -->
- [ ] ✨ 새로운 API 추가
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] ♻️ 리팩토링
- [ ] 🔧 인프라/환경 설정
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 강화

## 📋 작업 내용

- 엑세스토큰 없이 리프레시토큰만 보유한 상태에서는 토큰재발급 요청이 안되는 버그 해결
- 엑세스토큰을 만료하기 위한 토큰 재발행 요청에서 엑세스토큰을 검사하지 않도록 수정
- 엑세스토큰 재발행은 시큐리티필터에서 인증되지 않은 사용자도 할 수 있도록 허용
- 엑세스토큰이 없을때, 유효하지 않은 엑세스토큰으로 요청시 401 에러로 처리될 수 있도록 로직 수정 

### 주요 변경사항

- 스프링시큐리티설정 파일에서 토큰재발행(/api/v1/token-refresh) 요청에 대하여 인증 통과(permitAll) 처리
- 시큐리티필터체인 이전에 동작하는 Jwt인증필터에서 인증없이 통과할 수 있는 화이트리스트 경로 추가
- 토큰이 없거나, 유효하지 않거나, 토큰 정보 해석하는데 실패한 경우 401 응답으로 처리될 수 있도록 수정 (기존 403 응답)


## 🔗 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: #123 -->
> Closes #57 


## 🖥️ 백엔드 체크리스트
- [ ] API 문서 업데이트 (Swagger/Postman)
- [ ] 데이터베이스 스키마 변경사항 확인
- [ ] 환경 변수 변경사항 문서화
- [ ] 로그 및 모니터링 설정
- [ ] 에러 핸들링 및 응답 코드 확인
- [x] 보안 검토 (인증/인가, 입력 검증)
- [ ] 성능 테스트 (필요시)


## ⚠️ 주의사항
<!-- 배포나 운영 시 주의해야 할 사항 -->
- [ ] 환경 변수 설정 필요
- [ ] 데이터베이스 마이그레이션 필요
- [ ] 외부 API 의존성 추가
- [x] 서버 재시작 필요
