### PR TITLE
대시보드 통합조회 추가

### DIFF
--- a/src/main/java/com/kcc/groo/challenge/data/dto/UserBadgeStatusResponse.java
+++ b/src/main/java/com/kcc/groo/challenge/data/dto/UserBadgeStatusResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 /**
  * 사용자의 뱃지 획득 상태를 포함한 뱃지 정보 응답 DTO
+ *
  * @author uyh
  * @created 2025-10-16
  */
@@ -43,10 +44,10 @@ public class UserBadgeStatusResponse {
     private LocalDateTime acquiredDate;
 
     /**
-     * @param badge 뱃지 엔티티
+     * @param badge           뱃지 엔티티
      * @param currentProgress 현재 진행도
-     * @param acquired 획득 여부
-     * @param acquiredDate 획득 날짜
+     * @param acquired        획득 여부
+     * @param acquiredDate    획득 날짜
      * @return UserBadgeStatusResponse
      * @author uyh
      * @created 2025-10-16

--- a/src/main/java/com/kcc/groo/challenge/service/ChallengeService.java
+++ b/src/main/java/com/kcc/groo/challenge/service/ChallengeService.java
@@ -5,7 +5,7 @@ import com.kcc.groo.challenge.dao.IBadgeRepository;
 import com.kcc.groo.challenge.data.dto.UserBadgeResponse;
 import com.kcc.groo.challenge.data.dto.UserBadgeStatusResponse;
 import com.kcc.groo.challenge.data.model.Badge;
-import com.kcc.groo.review.dao.ICommentRepository;
+import com.kcc.groo.review.dao.IReviewCommentRepository;
 import com.kcc.groo.review.dao.IReviewRepository;
 import com.kcc.groo.user.dao.IFollowsRepository;
 import com.kcc.groo.user.dao.IUsersRepository;
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 /**
  * 도전과제 및 뱃지 부여 관련 비즈니스 로직을 처리하는 서비스 클래스
+ *
  * @author uyh
  * @created 2025-10-16
  */
@@ -37,7 +38,7 @@ public class ChallengeService implements IChallengeService {
     private final IUsersRepository usersRepository;
     private final IFollowsRepository followsRepository;
     private final IReviewRepository reviewRepository;
-    private final ICommentRepository commentRepository;
+    private final IReviewCommentRepository commentRepository;
     private final IBookScrapRepository bookScrapRepository;
 
     /**
@@ -165,7 +166,7 @@ public class ChallengeService implements IChallengeService {
 
     /**
      * @param userId 사용자 ID
-     * @param isbn 도서 ISBN
+     * @param isbn   도서 ISBN
      * @return void
      * @author uyh
      * @created 2025-10-16

--- a/src/main/java/com/kcc/groo/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/kcc/groo/dashboard/controller/DashboardController.java
@@ -1,22 +1,17 @@
 package com.kcc.groo.dashboard.controller;
 
+import com.kcc.groo.common.dto.CommonResponse;
+import com.kcc.groo.dashboard.data.dto.*;
+import com.kcc.groo.dashboard.service.IDashboardService;
+import com.kcc.groo.jwt.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.kcc.groo.common.dto.CommonResponse;
-import com.kcc.groo.dashboard.data.dto.DashboardSummaryResponse;
-import com.kcc.groo.dashboard.data.dto.MonthlyReportResponse;
-import com.kcc.groo.dashboard.data.dto.MonthlyStatsResponse;
-import com.kcc.groo.dashboard.data.dto.YearlyStatsResponse;
-import com.kcc.groo.dashboard.service.IDashboardService;
-import com.kcc.groo.jwt.JwtTokenProvider;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * @author uyh
@@ -33,6 +28,26 @@ public class DashboardController {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 대시보드 페이지에 필요한 전체 데이터 조회
+     *
+     * @param request HTTP 요청 객체
+     * @return 대시보드 전체 데이터
+     * @author YunSung
+     * @created 2025-10-25
+     */
+    @GetMapping("/all")
+    public ResponseEntity<CommonResponse<DashboardAllDataResponseDTO>> getDashboardAllData(HttpServletRequest request) {
+        // JWT 토큰에서 사용자 ID 추출
+        String userId = jwtTokenProvider.getUserId(jwtTokenProvider.resolveAccessToken(request));
+
+        // 대시보드 전체 데이터 조회
+        DashboardAllDataResponseDTO dashboardAllData = dashboardService.getDashboardAllData(userId);
+
+        // 200 응답 반환.
+        return ResponseEntity.ok(new CommonResponse<>("대시보드 전체 데이터 조회 성공", dashboardAllData));
+    }
 
     @Operation(summary = "대시보드 기본 통계 조회",
             description = "작성한 독후감 개수, 스크랩한 도서 개수, 좋아요 누른 독후감 개수, 카테고리별 독서 통계를 조회합니다.")

--- a/src/main/java/com/kcc/groo/dashboard/data/dto/DashboardAllDataResponseDTO.java
+++ b/src/main/java/com/kcc/groo/dashboard/data/dto/DashboardAllDataResponseDTO.java
@@ -1,0 +1,39 @@
+package com.kcc.groo.dashboard.data.dto;
+
+import com.kcc.groo.user.data.dto.FollowUserInfoDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DashboardAllDataResponseDTO {
+
+    private List<FollowUserInfoDTO> followers;
+
+    private List<FollowUserInfoDTO> followings;
+
+    private int totalReviews;
+
+    private int totalScrappedBooks;
+
+    private int totalLikedReviews;
+
+    private List<MonthlyStat> monthlyStats;
+
+    private List<YearlyStat> yearlyStats;
+
+    private List<CategoryStat> categoryStats;
+
+    private ReportInfo reportInfo;
+
+    @Getter
+    @Builder
+    public static class ReportInfo {
+        private int myAverage;
+        private double totalAverage;
+        private int year;
+        private int month;
+    }
+}

--- a/src/main/java/com/kcc/groo/dashboard/service/DashboardService.java
+++ b/src/main/java/com/kcc/groo/dashboard/service/DashboardService.java
@@ -4,6 +4,8 @@ import com.kcc.groo.common.exception.GrooException;
 import com.kcc.groo.dashboard.dao.IDashboardRepository;
 import com.kcc.groo.dashboard.data.dto.*;
 import com.kcc.groo.dashboard.exception.DashboardErrorCode;
+import com.kcc.groo.user.dao.IFollowsRepository;
+import com.kcc.groo.user.data.dto.FollowUserInfoDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,56 @@ public class DashboardService implements IDashboardService {
 
     @Autowired
     private IDashboardRepository dashboardRepository;
+
+    @Autowired
+    private IFollowsRepository iFollowsRepository;
+
+    @Override
+    public DashboardAllDataResponseDTO getDashboardAllData(String userId) {
+        // 현재 연월 정보
+        LocalDate now = LocalDate.now();
+        int year = now.getYear();
+        int month = now.getMonthValue();
+
+        // 팔로워 및 팔로잉 목록 조회
+        List<FollowUserInfoDTO> followers = iFollowsRepository.selectFollowerList(userId);
+        List<FollowUserInfoDTO> followings = iFollowsRepository.selectFollowingList(userId);
+
+        // 작성한 독후감 개수, 스크랩한 도서 개수, 좋아요 누른 독후감 개수 조회
+        int totalReviews = dashboardRepository.countReviewsByUser(userId);
+        int totalScrappedBooks = dashboardRepository.countScrappedBooks(userId);
+        int totalLikedReviews = dashboardRepository.countLikedReviews(userId);
+
+        // 월별, 연도별 독서량 통계
+        List<MonthlyStat> monthlyStats = dashboardRepository.getMonthlyReviewStats(userId, java.time.LocalDate.now().getYear());
+        List<YearlyStat> yearlyStats = dashboardRepository.findYearlyStats(userId);
+
+        // 카테고리별 독서 통계 조회
+        List<CategoryStat> categoryStats = dashboardRepository.getCategoryStats(userId);
+
+        // 월간 리포트 정보 조회
+        int myAverage = dashboardRepository.getMonthlyReviewCount(userId, year, month);
+        Double AllUserAverage = dashboardRepository.getAverageMonthlyReviewCount(year, month);
+        double totalAverage = (AllUserAverage != null) ? AllUserAverage : 0.0;
+
+        // 대시보드 전체 데이터 응답 DTO 생성 및 반환
+        return DashboardAllDataResponseDTO.builder()
+                .followers(followers)
+                .followings(followings)
+                .totalReviews(totalReviews)
+                .totalScrappedBooks(totalScrappedBooks)
+                .totalLikedReviews(totalLikedReviews)
+                .monthlyStats(monthlyStats)
+                .yearlyStats(yearlyStats)
+                .categoryStats(categoryStats)
+                .reportInfo(DashboardAllDataResponseDTO.ReportInfo.builder()
+                        .myAverage(myAverage)
+                        .totalAverage(totalAverage)
+                        .year(year)
+                        .month(month)
+                        .build())
+                .build();
+    }
 
     @Override
     public DashboardSummaryResponse getSummaryStats(String userId) {

--- a/src/main/java/com/kcc/groo/dashboard/service/IDashboardService.java
+++ b/src/main/java/com/kcc/groo/dashboard/service/IDashboardService.java
@@ -1,9 +1,6 @@
 package com.kcc.groo.dashboard.service;
 
-import com.kcc.groo.dashboard.data.dto.DashboardSummaryResponse;
-import com.kcc.groo.dashboard.data.dto.MonthlyStatsResponse;
-import com.kcc.groo.dashboard.data.dto.MonthlyReportResponse;
-import com.kcc.groo.dashboard.data.dto.YearlyStatsResponse;
+import com.kcc.groo.dashboard.data.dto.*;
 
 /**
  * @author uyh
@@ -11,6 +8,16 @@ import com.kcc.groo.dashboard.data.dto.YearlyStatsResponse;
  * Dashboard Service Interface
  */
 public interface IDashboardService {
+
+    /**
+     * 대시보드 페이지에 필요한 전체 데이터 조회
+     *
+     * @param userId 로그인 사용자 ID
+     * @return 대시보드 전체 데이터 DTO
+     * @author YunSung
+     * @created 2025-10-25
+     */
+    DashboardAllDataResponseDTO getDashboardAllData(String userId);
 
     /**
      * @param userId
@@ -44,6 +51,7 @@ public interface IDashboardService {
 
     /**
      * 연도별 독후감 통계 조회
+     *
      * @param userId 로그인 사용자 ID
      * @return 연도별 통계 리스트
      */

--- a/src/main/java/com/kcc/groo/review/controller/ReviewCommentController.java
+++ b/src/main/java/com/kcc/groo/review/controller/ReviewCommentController.java
@@ -2,7 +2,7 @@ package com.kcc.groo.review.controller;
 
 import com.kcc.groo.review.data.dto.CommentRequest;
 import com.kcc.groo.review.data.dto.CommentResponse;
-import com.kcc.groo.review.service.ICommentService;
+import com.kcc.groo.review.service.IReviewCommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +16,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/comments")
 @RequiredArgsConstructor
-public class CommentApiController {
+public class ReviewCommentController {
 
-    private final ICommentService commentService;
+    private final IReviewCommentService commentService;
 
     /**
-     * @param reviewId 댓글을 작성할 리뷰 ID
+     * @param reviewId  댓글을 작성할 리뷰 ID
      * @param principal 인증된 사용자 정보
-     * @param req 댓글 내용
+     * @param req       댓글 내용
      * @return ResponseEntity<Void>
      * @author uyh
      * @created 2025-09-29
@@ -43,7 +43,7 @@ public class CommentApiController {
     /**
      * @param commentId 수정할 댓글 ID
      * @param principal 인증된 사용자 정보
-     * @param req 수정할 댓글 내용
+     * @param req       수정할 댓글 내용
      * @return ResponseEntity<Void>
      * @author uyh
      * @created 2025-09-29
@@ -80,7 +80,6 @@ public class CommentApiController {
 
     /**
      * @param reviewId 조회할 리뷰 ID
-     * @param userId 조회하는 사용자 ID (null 가능)
      * @return List<CommentResponse>
      * @author uyh
      * @created 2025-09-29

--- a/src/main/java/com/kcc/groo/review/controller/ReviewController.java
+++ b/src/main/java/com/kcc/groo/review/controller/ReviewController.java
@@ -1,6 +1,8 @@
 package com.kcc.groo.review.controller;
 
-import com.kcc.groo.review.data.dto.*;
+import com.kcc.groo.review.data.dto.ReviewCreateRequest;
+import com.kcc.groo.review.data.dto.ReviewResponse;
+import com.kcc.groo.review.data.dto.ReviewUpdateRequest;
 import com.kcc.groo.review.service.IReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,13 +17,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/reviews")
 @RequiredArgsConstructor
-public class ReviewApiController {
+public class ReviewController {
 
     private final IReviewService reviewService;
 
     /**
      * @param principal 인증된 사용자 정보
-     * @param request 독후감 작성 정보
+     * @param request   독후감 작성 정보
      * @return ResponseEntity<Void>
      * @author uyh
      * @created 2025-09-28
@@ -52,7 +54,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param id 조회할 임시저장 글 ID
+     * @param id        조회할 임시저장 글 ID
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<ReviewResponse>
      * @author uyh
@@ -69,7 +71,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param id 삭제할 임시저장 글 ID
+     * @param id        삭제할 임시저장 글 ID
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<Void>
      * @author uyh
@@ -87,7 +89,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param reviewId 조회할 리뷰 ID
+     * @param reviewId  조회할 리뷰 ID
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<ReviewResponse>
      * @author uyh
@@ -118,9 +120,9 @@ public class ReviewApiController {
     }
 
     /**
-     * @param reviewId 수정할 리뷰 ID
+     * @param reviewId  수정할 리뷰 ID
      * @param principal 인증된 사용자 정보
-     * @param request 수정할 독후감 정보
+     * @param request   수정할 독후감 정보
      * @return ResponseEntity<Void>
      * @author uyh
      * @created 2025-09-28
@@ -152,7 +154,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param reviewId 삭제할 리뷰 ID
+     * @param reviewId  삭제할 리뷰 ID
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<Void>
      * @author uyh
@@ -170,7 +172,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param reviewId 좋아요할 리뷰 ID
+     * @param reviewId  좋아요할 리뷰 ID
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<Void>
      * @author uyh
@@ -188,7 +190,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param reviewId 좋아요 취소할 리뷰 ID
+     * @param reviewId  좋아요 취소할 리뷰 ID
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<Void>
      * @author uyh
@@ -218,7 +220,7 @@ public class ReviewApiController {
         String userId = principal.getName();
         return ResponseEntity.ok(reviewService.getLikedReviews(userId));
     }
-    
+
     /**
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<List<ReviewResponse>>
@@ -232,7 +234,7 @@ public class ReviewApiController {
         String userId = principal.getName();
         return ResponseEntity.ok(reviewService.getReviewsByFollowing(userId));
     }
-    
+
     /**
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<List<ReviewResponse>>
@@ -246,9 +248,9 @@ public class ReviewApiController {
         String userId = principal != null ? principal.getName() : null;
         return ResponseEntity.ok(reviewService.getAllReviewsOrderByLikes(userId));
     }
-    
+
     /**
-     * @param isbn 조회할 도서의 ISBN
+     * @param isbn      조회할 도서의 ISBN
      * @param principal 인증된 사용자 정보
      * @return ResponseEntity<List<ReviewResponse>>
      * @author uyh
@@ -263,11 +265,11 @@ public class ReviewApiController {
         String userId = principal != null ? principal.getName() : null;
         return ResponseEntity.ok(reviewService.getReviewsByIsbn(isbn, userId));
     }
-    
+
 
     /**
      * TODO
-     * 
+     *
      * @param category
      * @param limit
      * @param principal
@@ -287,7 +289,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param userId 조회할 사용자 ID
+     * @param userId    조회할 사용자 ID
      * @param principal 인증된 사용자 정보 (선택)
      * @return ResponseEntity<List<ReviewResponse>>
      * @author uyh
@@ -304,7 +306,7 @@ public class ReviewApiController {
     }
 
     /**
-     * @param userId 조회할 사용자 ID
+     * @param userId    조회할 사용자 ID
      * @param principal 인증된 사용자 정보 (선택)
      * @return ResponseEntity<List<ReviewResponse>>
      * @author uyh
@@ -319,5 +321,5 @@ public class ReviewApiController {
         String currentUserId = principal != null ? principal.getName() : null;
         return ResponseEntity.ok(reviewService.getLikedReviewsByUser(currentUserId, userId));
     }
-    
+
 }

--- a/src/main/java/com/kcc/groo/review/dao/IReviewCommentRepository.java
+++ b/src/main/java/com/kcc/groo/review/dao/IReviewCommentRepository.java
@@ -8,12 +8,12 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 @Mapper
-public interface ICommentRepository {
+public interface IReviewCommentRepository {
 
     /**
      * @param reviewId 댓글을 작성할 리뷰 ID
-     * @param userId 댓글 작성자 ID
-     * @param req 댓글 내용
+     * @param userId   댓글 작성자 ID
+     * @param req      댓글 내용
      * @return void
      * @author uyh
      * @created 2025-09-29
@@ -25,8 +25,8 @@ public interface ICommentRepository {
 
     /**
      * @param commentId 수정할 댓글 ID
-     * @param userId 댓글 작성자 ID
-     * @param content 수정할 댓글 내용
+     * @param userId    댓글 작성자 ID
+     * @param content   수정할 댓글 내용
      * @return void
      * @author uyh
      * @created 2025-09-29
@@ -38,7 +38,7 @@ public interface ICommentRepository {
 
     /**
      * @param commentId 삭제할 댓글 ID
-     * @param userId 댓글 작성자 ID
+     * @param userId    댓글 작성자 ID
      * @return void
      * @author uyh
      * @created 2025-09-29
@@ -49,7 +49,7 @@ public interface ICommentRepository {
 
     /**
      * @param reviewId 조회할 리뷰 ID
-     * @param userId 조회하는 사용자 ID (null 가능)
+     * @param userId   조회하는 사용자 ID (null 가능)
      * @return List<CommentResponse>
      * @author uyh
      * @created 2025-09-29
@@ -84,7 +84,7 @@ public interface ICommentRepository {
      * 특정 사용자가 작성한 모든 댓글 수를 조회
      */
     int countCommentsByUserId(@Param("userId") String userId);
-    
+
     /**
      * @return
      * @author kys

--- a/src/main/java/com/kcc/groo/review/service/IReviewCommentService.java
+++ b/src/main/java/com/kcc/groo/review/service/IReviewCommentService.java
@@ -5,32 +5,32 @@ import com.kcc.groo.review.data.dto.CommentResponse;
 
 import java.util.List;
 
-public interface ICommentService {
-    
+public interface IReviewCommentService {
+
     /**
-     * @param userId 댓글 작성자 ID
+     * @param userId   댓글 작성자 ID
      * @param reviewId 댓글을 작성할 리뷰 ID
-     * @param req 댓글 내용
+     * @param req      댓글 내용
      * @return void
      * @author uyh
      * @created 2025-09-29
      * 리뷰에 댓글을 추가
      */
     void addComment(String userId, Integer reviewId, CommentRequest req);
-    
+
     /**
-     * @param userId 댓글 작성자 ID
+     * @param userId    댓글 작성자 ID
      * @param commentId 수정할 댓글 ID
-     * @param content 수정할 댓글 내용
+     * @param content   수정할 댓글 내용
      * @return void
      * @author uyh
      * @created 2025-09-29
      * 본인이 작성한 댓글을 수정
      */
     void updateComment(String userId, Integer commentId, String content);
-    
+
     /**
-     * @param userId 댓글 작성자 ID
+     * @param userId    댓글 작성자 ID
      * @param commentId 삭제할 댓글 ID
      * @return void
      * @author uyh
@@ -38,10 +38,10 @@ public interface ICommentService {
      * 본인이 작성한 댓글을 삭제
      */
     void deleteComment(String userId, Integer commentId);
-    
+
     /**
      * @param reviewId 조회할 리뷰 ID
-     * @param userId 조회하는 사용자 ID (null 가능)
+     * @param userId   조회하는 사용자 ID (null 가능)
      * @return List<CommentResponse>
      * @author uyh
      * @created 2025-09-29
@@ -49,7 +49,7 @@ public interface ICommentService {
      * 특정 리뷰의 모든 댓글을 조회
      */
     List<CommentResponse> getCommentsByReview(Integer reviewId, String userId);
-    
+
     /**
      * @param userId 댓글 작성자 ID
      * @return List<CommentResponse>

--- a/src/main/java/com/kcc/groo/review/service/ReviewCommentService.java
+++ b/src/main/java/com/kcc/groo/review/service/ReviewCommentService.java
@@ -3,7 +3,7 @@ package com.kcc.groo.review.service;
 import com.kcc.groo.common.exception.GrooException;
 import com.kcc.groo.notification.data.dto.NotificationRequest;
 import com.kcc.groo.notification.service.INotificationService;
-import com.kcc.groo.review.dao.ICommentRepository;
+import com.kcc.groo.review.dao.IReviewCommentRepository;
 import com.kcc.groo.review.dao.IReviewRepository;
 import com.kcc.groo.review.data.dto.CommentRequest;
 import com.kcc.groo.review.data.dto.CommentResponse;
@@ -20,9 +20,9 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CommentService implements ICommentService {
+public class ReviewCommentService implements IReviewCommentService {
 
-    private final ICommentRepository commentRepository;
+    private final IReviewCommentRepository commentRepository;
     private final IReviewRepository reviewRepository;
     private final INotificationService notificationService;
 

--- a/src/main/java/com/kcc/groo/review/service/ReviewService.java
+++ b/src/main/java/com/kcc/groo/review/service/ReviewService.java
@@ -4,7 +4,7 @@ import com.kcc.groo.challenge.service.IChallengeService;
 import com.kcc.groo.common.exception.GrooException;
 import com.kcc.groo.notification.data.dto.NotificationRequest;
 import com.kcc.groo.notification.service.INotificationService;
-import com.kcc.groo.review.dao.ICommentRepository;
+import com.kcc.groo.review.dao.IReviewCommentRepository;
 import com.kcc.groo.review.dao.IReviewRepository;
 import com.kcc.groo.review.data.dto.ReviewCreateRequest;
 import com.kcc.groo.review.data.dto.ReviewResponse;
@@ -25,7 +25,7 @@ import java.util.List;
 public class ReviewService implements IReviewService {
 
     private final IReviewRepository reviewRepository;
-    private final ICommentRepository commentRepository;
+    private final IReviewCommentRepository commentRepository;
     private final IChallengeService challengeService; // 의존성 주입
     private final INotificationService notificationService; //added 2025-10-21 kys
 

--- a/src/main/resources/mapper/reviews/ReviewCommentMapper.xml
+++ b/src/main/resources/mapper/reviews/ReviewCommentMapper.xml
@@ -3,7 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.kcc.groo.review.dao.ICommentRepository">
+<mapper namespace="com.kcc.groo.review.dao.IReviewCommentRepository">
 
     <!-- ResultMap 추가 -->
     <resultMap id="commentResultMap" type="com.kcc.groo.review.data.dto.CommentResponse">
@@ -44,37 +44,37 @@
     <!-- 댓글 단건 조회 -->
     <select id="selectCommentById" resultMap="commentResultMap">
         <![CDATA[
-		SELECT
-			comment_id AS commentId,
-			content AS content,
-			user_id AS userId,
-			created_at AS createdAt,
-			updated_at AS updatedAt,
-			parent_id AS parentId,
-			review_id AS reviewId
-		FROM review_comments
-		WHERE comment_id = #{commentId}
-		]]>
+        SELECT comment_id AS commentId,
+               content    AS content,
+               user_id    AS userId,
+               created_at AS createdAt,
+               updated_at AS updatedAt,
+               parent_id  AS parentId,
+               review_id  AS reviewId
+        FROM review_comments
+        WHERE comment_id = #{commentId}
+        ]]>
     </select>
 
     <!-- 댓글 수정 -->
     <update id="updateComment">
         <![CDATA[
-		UPDATE review_comments
-		SET content = #{content},
-			updated_at = CURRENT_TIMESTAMP
-		WHERE comment_id = #{commentId}
-		AND user_id = #{userId}
-		]]>
+        UPDATE review_comments
+        SET content    = #{content},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE comment_id = #{commentId}
+          AND user_id = #{userId}
+        ]]>
     </update>
 
     <!-- 댓글 삭제 -->
     <delete id="deleteComment">
         <![CDATA[
-		DELETE FROM review_comments
-		WHERE comment_id = #{commentId}
-		AND user_id = #{userId}
-		]]>
+        DELETE
+        FROM review_comments
+        WHERE comment_id = #{commentId}
+          AND user_id = #{userId}
+        ]]>
     </delete>
 
     <!-- 특정 리뷰의 댓글 조회 -->
@@ -111,33 +111,34 @@
     <!-- 내가 쓴 모든 댓글 조회 -->
     <select id="selectCommentsByUser" resultMap="commentResultMap">
         <![CDATA[
-		SELECT
-			c.comment_id AS commentId,
-			c.content AS content,
-			c.user_id AS userId,
-			c.review_id AS reviewId,
-			CASE
-				WHEN r.status = TRUE THEN r.review_title
-				ELSE '삭제된 게시글입니다'
-			END AS reviewTitle,
-			c.created_at AS createdAt,
-			c.updated_at AS updatedAt,
-			c.parent_id AS parentId
-		FROM review_comments c
-		JOIN reviews r ON c.review_id = r.review_id
-		WHERE c.user_id = #{userId}
-		ORDER BY c.created_at DESC
-		]]>
+        SELECT c.comment_id AS commentId,
+               c.content    AS content,
+               c.user_id    AS userId,
+               c.review_id  AS reviewId,
+               CASE
+                   WHEN r.status = TRUE THEN r.review_title
+                   ELSE '삭제된 게시글입니다'
+                   END      AS reviewTitle,
+               c.created_at AS createdAt,
+               c.updated_at AS updatedAt,
+               c.parent_id  AS parentId
+        FROM review_comments c
+                 JOIN reviews r ON c.review_id = r.review_id
+        WHERE c.user_id = #{userId}
+        ORDER BY c.created_at DESC
+        ]]>
     </select>
 
     <select id="countCommentsByUserId" parameterType="String" resultType="int">
         <![CDATA[
-        SELECT COUNT(*) FROM review_comments WHERE user_id = #{userId}
+        SELECT COUNT(*)
+        FROM review_comments
+        WHERE user_id = #{userId}
         ]]>
     </select>
 
-<select id="selectLastInsertedCommentId" resultType="int">
-    SELECT LAST_INSERT_ID()
-</select>
+    <select id="selectLastInsertedCommentId" resultType="int">
+        SELECT LAST_INSERT_ID()
+    </select>
 
 </mapper>


### PR DESCRIPTION
# Pull Request - Backend

## 🎯 Purpose

대시보드 페이지에서 필요한 데이터를 컴포넌트에서 개별적으로 조회중이던 문제 해결

- [x] ✨ 새로운 API 추가
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] ♻️ 리팩토링
- [ ] 🔧 인프라/환경 설정
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 강화

## 📋 작업 내용

대시보드 페이지에 필요한 모든 데이터를 한번에 조회할 수 있는 기능 추가

### API 변경사항
<!-- 새로 추가된 엔드포인트나 변경된 API가 있다면 -->
- **GET** /dashboard/all - 월간/년간, 분야별, 리포트 등등 대시보드 데이터 통합조회

## 🔗 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: #123 -->
> Closes #94 


### 특별히 확인해주세요
@umyunho 
