### PR TITLE
fix: ERR_HTTP2_PROTOCOL_ERROR 해결을 위한 HTTP/1.1 강제 설정

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -130,8 +130,13 @@ server {
 
     # ===============================================================
     # SSE (Server-Sent Events) - 실시간 알림 스트림 전용
+    # ERR_HTTP2_PROTOCOL_ERROR 해결을 위한 HTTP/1.1 강제 설정
     # ===============================================================
     location /api/v1/alarms/subscribe {
+        # HTTP/2 명시적 비활성화 (nginx 1.19.7+ 지원)
+        # HTTP/2는 SSE와 호환되지 않으므로 HTTP/1.1 강제
+        http2 off;
+
         proxy_pass http://groo-backend:8080;
 
         proxy_set_header Host $host;
@@ -139,16 +144,23 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
+        # nginx -> backend 간 HTTP/1.1 사용
         proxy_http_version 1.1;
         proxy_set_header Connection '';
+        proxy_set_header Upgrade $http_upgrade;
 
         # Nginx 버퍼링 끄기 (SSE가 끊기지 않게)
         chunked_transfer_encoding off;
         proxy_buffering off;
         proxy_cache off;
 
-        # ️ 백엔드와 동일한 타임아웃
+        # 백엔드와 동일한 타임아웃
         proxy_read_timeout 1h;
+        proxy_connect_timeout 1h;
+        proxy_send_timeout 1h;
+
+        # keepalive 연결 유지
+        proxy_socket_keepalive on;
 
         # CORS 허용 (프런트가 groo.site이므로)
         add_header 'Access-Control-Allow-Origin' 'https://groo.site' always;
@@ -185,7 +197,7 @@ server {
             add_header 'Access-Control-Allow-Origin' $http_origin always; # 요청한 Origin을 그대로 허용
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always; # 필요한 헤더 명시
-            add_header 'Access-Control-Allow-Credentials' 'true' always; # ★★★ 인증 정보 허용 헤더 추가
+            add_header 'Access-Control-Allow-Credentials' 'true' always; # 인증 정보 허용 헤더 추가
             add_header 'Content-Length' 0;
             return 204;
         }

--- a/nginx/default.local.conf
+++ b/nginx/default.local.conf
@@ -113,6 +113,7 @@ server {
 
     # =================================================================
     # SSE (Server-Sent Events) 실시간 알림 스트림
+    # ERR_HTTP2_PROTOCOL_ERROR 해결을 위한 HTTP/1.1 강제 설정
     # =================================================================
     location /api/v1/alarms/subscribe {
         proxy_pass http://backend_upstream;
@@ -122,14 +123,25 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # SSE는 반드시 아래 설정이 필요합니다
+        # nginx -> backend 간 HTTP/1.1 사용
         proxy_http_version 1.1;
         proxy_set_header Connection '';
+        proxy_set_header Upgrade $http_upgrade;
+
+        # SSE 필수 설정
         chunked_transfer_encoding off;
         proxy_buffering off;
         proxy_cache off;
-        proxy_read_timeout 1h; # SSE 연결 유지시간 (백엔드와 동일하게)
 
+        # 연결 유지시간 (백엔드와 동일하게)
+        proxy_read_timeout 1h;
+        proxy_connect_timeout 1h;
+        proxy_send_timeout 1h;
+
+        # keepalive 연결 유지
+        proxy_socket_keepalive on;
+
+        # CORS 허용 (로컬 개발 환경)
         add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
         add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;


### PR DESCRIPTION
# Pull Request - Backend

## 🎯 Purpose
<!-- 이 PR의 목적을 명확히 설명해주세요 -->
- [ ] ✨ 새로운 API 추가
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [x] ♻️ 리팩토링
- [ ] 🔧 인프라/환경 설정
- [ ] ⚡ 성능 개선
- [ ] 🔒 보안 강화

## 📋 작업 내용
<!-- 구체적으로 무엇을 변경했는지 설명해주세요 -->

### 주요 변경사항
- HTTP/2 명시적 비활성화 (nginx 1.19.7+ 지원)
- HTTP/2는 SSE와 호환되지 않으므로 HTTP/1.1 강제
